### PR TITLE
Raise cancelations

### DIFF
--- a/FirebaseUI.xcodeproj/project.pbxproj
+++ b/FirebaseUI.xcodeproj/project.pbxproj
@@ -612,7 +612,7 @@
 					"$(PROJECT_DIR)/target/Products/Release-combined",
 					"$(PROJECT_DIR)/target/Products/Release-iphoneos",
 					"$(PROJECT_DIR)/target/Products/Release-iphonesimulator",
-					"$(PROJECT_DIR)/sdk/google_signin_sdk_2_2_0",
+					"$(PROJECT_DIR)/sdk/google_signin_sdk_2_4_0",
 				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"LOCAL_BUILD=1",
@@ -657,7 +657,7 @@
 					"$(PROJECT_DIR)/target/Products/Release-combined",
 					"$(PROJECT_DIR)/target/Products/Release-iphoneos",
 					"$(PROJECT_DIR)/target/Products/Release-iphonesimulator",
-					"$(PROJECT_DIR)/sdk/google_signin_sdk_2_2_0",
+					"$(PROJECT_DIR)/sdk/google_signin_sdk_2_4_0",
 				);
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				GCC_WARN_PEDANTIC = YES;

--- a/FirebaseUI/Core/API/FirebaseArrayDelegate.h
+++ b/FirebaseUI/Core/API/FirebaseArrayDelegate.h
@@ -84,4 +84,10 @@
  */
 - (void)childMoved:(id)object fromIndex:(NSUInteger)fromIndex toIndex:(NSUInteger)toIndex;
 
+/**
+ * Delegate method which is called whenever the backing query is canceled.
+ * @param error the error that was raised
+ */
+- (void)canceledWithError:(NSError *)error;
+
 @end

--- a/FirebaseUI/Core/API/FirebaseDataSource.h
+++ b/FirebaseUI/Core/API/FirebaseDataSource.h
@@ -68,4 +68,10 @@
  */
 - (Firebase *)refForIndex:(NSUInteger)index;
 
+/**
+ * Provides a block which is called when the backing array cancels its query.
+ * @param block the block
+ */
+- (void)cancelWithBlock:(void (^)(NSError *error))block;
+
 @end

--- a/FirebaseUI/Core/Implementation/FirebaseArray.m
+++ b/FirebaseUI/Core/Implementation/FirebaseArray.m
@@ -74,6 +74,9 @@
         [self.snapshots insertObject:snapshot atIndex:index];
 
         [self.delegate childAdded:snapshot atIndex:index];
+      }
+      withCancelBlock:^(NSError *error) {
+        [self.delegate canceledWithError:error];
       }];
 
   [self.query observeEventType:FEventTypeChildChanged
@@ -83,16 +86,22 @@
         [self.snapshots replaceObjectAtIndex:index withObject:snapshot];
 
         [self.delegate childChanged:snapshot atIndex:index];
+      }
+      withCancelBlock:^(NSError *error) {
+        [self.delegate canceledWithError:error];
       }];
 
   [self.query observeEventType:FEventTypeChildRemoved
-                     withBlock:^(FDataSnapshot *snapshot) {
-                       NSUInteger index = [self indexForKey:snapshot.key];
+      withBlock:^(FDataSnapshot *snapshot) {
+        NSUInteger index = [self indexForKey:snapshot.key];
 
-                       [self.snapshots removeObjectAtIndex:index];
+        [self.snapshots removeObjectAtIndex:index];
 
-                       [self.delegate childRemoved:snapshot atIndex:index];
-                     }];
+        [self.delegate childRemoved:snapshot atIndex:index];
+      }
+      withCancelBlock:^(NSError *error) {
+        [self.delegate canceledWithError:error];
+      }];
 
   [self.query observeEventType:FEventTypeChildMoved
       andPreviousSiblingKeyWithBlock:^(FDataSnapshot *snapshot, NSString *previousChildKey) {
@@ -103,6 +112,9 @@
         [self.snapshots insertObject:snapshot atIndex:toIndex];
 
         [self.delegate childMoved:snapshot fromIndex:fromIndex toIndex:toIndex];
+      }
+      withCancelBlock:^(NSError *error) {
+        [self.delegate canceledWithError:error];
       }];
 }
 

--- a/FirebaseUI/Core/Implementation/FirebaseDataSource.m
+++ b/FirebaseUI/Core/Implementation/FirebaseDataSource.m
@@ -34,6 +34,10 @@
 
 #import "FirebaseDataSource.h"
 
+@interface FirebaseDataSource ()
+@property(copy, nonatomic) void (^cancelBlock)(NSError *);
+@end
+
 @implementation FirebaseDataSource
 
 #pragma mark -
@@ -61,6 +65,19 @@
 
 - (Firebase *)refForIndex:(NSUInteger)index {
   return [self.array refForIndex:index];
+}
+
+- (void)cancelWithBlock:(void (^)(NSError *))block {
+  self.cancelBlock = block;
+}
+
+#pragma mark -
+#pragma mark FirebaseArrayDelegate methods
+
+- (void)canceledWithError:(NSError *)error {
+  if (self.cancelBlock != nil) {
+    self.cancelBlock(error);
+  }
 }
 
 @end

--- a/setup.sh
+++ b/setup.sh
@@ -18,7 +18,7 @@ FACEBOOK_SDK_DIR="$SCRIPT_DIR/sdk/facebook-sdk"
 FACEBOOK_SDK_ZIP_FILE="$SCRIPT_DIR/sdk/facebook-sdk.zip"
 GOOGLE_SDK_ZIP_FILE="$SDK_DIR/google-sdk.zip"
 GOOGLE_CORE_SDK_ZIP_FILE="$SDK_DIR/google-core-sdk.zip"
-GOOGLE_SDK_DIR="$SCRIPT_DIR/sdk/google_signin_sdk_2_2_0"
+GOOGLE_SDK_DIR="$SCRIPT_DIR/sdk/google_signin_sdk_2_4_0"
 GOOGLE_CORE_SDK_DIR="$SCRIPT_DIR/sdk/google-core-sdk.zip"
 
 echo "$SDK_DIR"


### PR DESCRIPTION
The intent of 588d3ee is for consumers to be able to detect when the backing query was canceled so that errors can be handled accordingly.

e6edbb4 is not related to this change but was necessary in order to be able to build the project.