### PR TITLE
RESTful fallback for large datasets

### DIFF
--- a/FirebaseUI.xcodeproj/project.pbxproj
+++ b/FirebaseUI.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		83D0E7EF1C13A62A00652C4A /* FRestDataSnapshot.m in Sources */ = {isa = PBXBuildFile; fileRef = 83D0E7ED1C13A62A00652C4A /* FRestDataSnapshot.m */; };
 		BB372B551B8BE4890046905E /* FirebaseTwitterAuthProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = BB372B541B8BE4890046905E /* FirebaseTwitterAuthProvider.m */; };
 		BB372B601B8D1B580046905E /* FirebaseTwitterAuthProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = BB372B531B8BE4510046905E /* FirebaseTwitterAuthProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BB4877901BA8A0C000FD3D4D /* GoogleSignIn.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BB48778F1BA8A0C000FD3D4D /* GoogleSignIn.framework */; };
@@ -93,6 +94,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		83D0E7EB1C13A60C00652C4A /* FRestDataSnapshot.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FRestDataSnapshot.h; path = Core/API/FRestDataSnapshot.h; sourceTree = "<group>"; };
+		83D0E7ED1C13A62A00652C4A /* FRestDataSnapshot.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FRestDataSnapshot.m; path = Core/Implementation/FRestDataSnapshot.m; sourceTree = "<group>"; };
+		83D0E7F01C13B21700652C4A /* FirebaseUIOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FirebaseUIOptions.h; path = Core/API/FirebaseUIOptions.h; sourceTree = "<group>"; };
 		BB372B531B8BE4510046905E /* FirebaseTwitterAuthProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FirebaseTwitterAuthProvider.h; path = Auth/API/FirebaseTwitterAuthProvider.h; sourceTree = "<group>"; };
 		BB372B541B8BE4890046905E /* FirebaseTwitterAuthProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FirebaseTwitterAuthProvider.m; path = Auth/Implementation/FirebaseTwitterAuthProvider.m; sourceTree = "<group>"; };
 		BB48778F1BA8A0C000FD3D4D /* GoogleSignIn.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleSignIn.framework; path = sdk/google_signin_sdk_2_2_0/GoogleSignIn.framework; sourceTree = "<group>"; };
@@ -283,6 +287,8 @@
 				D81495ED1BF5AF280099AE10 /* FirebaseCollectionViewDataSource.h */,
 				D81495EE1BF5AF280099AE10 /* FirebaseDataSource.h */,
 				D81495EF1BF5AF280099AE10 /* FirebaseTableViewDataSource.h */,
+				83D0E7EB1C13A60C00652C4A /* FRestDataSnapshot.h */,
+				83D0E7F01C13B21700652C4A /* FirebaseUIOptions.h */,
 			);
 			name = API;
 			sourceTree = "<group>";
@@ -294,6 +300,7 @@
 				D81495F81BF5AF460099AE10 /* FirebaseCollectionViewDataSource.m */,
 				D81495F91BF5AF460099AE10 /* FirebaseDataSource.m */,
 				D81495FA1BF5AF460099AE10 /* FirebaseTableViewDataSource.m */,
+				83D0E7ED1C13A62A00652C4A /* FRestDataSnapshot.m */,
 			);
 			name = Implementation;
 			sourceTree = "<group>";
@@ -485,6 +492,7 @@
 				D81496061BF5B92C0099AE10 /* FirebasePasswordAuthProvider.m in Sources */,
 				D81495FF1BF5AF460099AE10 /* FirebaseTableViewDataSource.m in Sources */,
 				D809A11E1BF67095000257AA /* FirebaseAuthConstants.m in Sources */,
+				83D0E7EF1C13A62A00652C4A /* FRestDataSnapshot.m in Sources */,
 				BBF6D41B1BA1FFAD00C644A7 /* FirebaseGoogleAuthProvider.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/FirebaseUI/Core/API/FRestDataSnapshot.h
+++ b/FirebaseUI/Core/API/FRestDataSnapshot.h
@@ -1,0 +1,13 @@
+//
+//  FRestDataSnapshot.h
+//  FirebaseUI
+//
+//  Created by Chris Ellsworth on 12/5/15.
+//  Copyright © 2015 Firebase, Inc. All rights reserved.
+//
+
+#import <Firebase/Firebase.h>
+
+@interface FRestDataSnapshot : FDataSnapshot
+- (instancetype)initWithRef:(Firebase *)ref value:(id)value;
+@end

--- a/FirebaseUI/Core/API/FirebaseArray.h
+++ b/FirebaseUI/Core/API/FirebaseArray.h
@@ -34,6 +34,7 @@
 #import <FirebaseUI/XCodeMacros.h>
 
 #import "FirebaseArrayDelegate.h"
+#import "FirebaseUIOptions.h"
 
 @class FQuery;
 @class Firebase;
@@ -62,6 +63,11 @@
  */
 @property(strong, nonatomic) NSMutableArray __GENERIC(FDataSnapshot *) * snapshots;
 
+/**
+ * Options for the FirebaseArray.
+ */
+@property(nonatomic) FirebaseUIOptions options;
+
 #pragma mark -
 #pragma mark Initializer methods
 
@@ -78,6 +84,14 @@
  * @return The instance of FirebaseArray
  */
 - (instancetype)initWithQuery:(FQuery *)query;
+
+/**
+ * Intitalizes FirebaseArray with a Firebase query (FQuery).
+ * @param query A query on a Firebase reference which provides filtered data to FirebaseArray
+ * @param options Options for the FirebaseArray.
+ * @return The instance of FirebaseArray
+ */
+- (instancetype)initWithQuery:(FQuery *)query options:(FirebaseUIOptions)options;
 
 #pragma mark -
 #pragma mark Public API methods

--- a/FirebaseUI/Core/API/FirebaseArrayDelegate.h
+++ b/FirebaseUI/Core/API/FirebaseArrayDelegate.h
@@ -85,6 +85,11 @@
 - (void)childMoved:(id)object fromIndex:(NSUInteger)fromIndex toIndex:(NSUInteger)toIndex;
 
 /**
+ * Delegate method which is called when the backing array is reloaded.
+ */
+- (void)dataReloaded;
+
+/**
  * Delegate method which is called whenever the backing query is canceled.
  * @param error the error that was raised
  */

--- a/FirebaseUI/Core/API/FirebaseCollectionViewDataSource.h
+++ b/FirebaseUI/Core/API/FirebaseCollectionViewDataSource.h
@@ -254,6 +254,53 @@
                                   view:(__NON_NULL UICollectionView *)collectionView;
 
 /**
+ * Initialize an instance of FirebaseCollectionViewDataSource that populates a
+ * custom subclass of
+ * UICollectionViewCell with a custom model class.
+ * @param ref A Firebase reference to bind the datasource to
+ * @param model A custom class that FDataSnapshots are coerced to, defaults to
+ * FDataSnapshot if nil
+ * @param cell A subclass of UICollectionViewCell used to populate the
+ * UICollectionView, defaults to
+ * UICollectionViewCell if nil
+ * @param identifier A string to use as a CellReuseIdentifier
+ * @param collectionView An instance of a UICollectionView to bind to
+ * @options Options for the FirebaseCollectionViewDataSource
+ * @return An instance of FirebaseCollectionViewDataSource that populates a
+ * custom subclass of
+ * UICollectionViewCell with a custom model class
+ */
+- (__NON_NULL instancetype)initWithRef:(__NON_NULL Firebase *)ref
+                            modelClass:(__NULLABLE Class)model
+                             cellClass:(__NULLABLE Class)cell
+                   cellReuseIdentifier:(__NON_NULL NSString *)identifier
+                                  view:(__NON_NULL UICollectionView *)collectionView
+                               options:(FirebaseUIOptions)options;
+
+/**
+ * Initialize an instance of FirebaseCollectionViewDataSource that populates a
+ * custom xib with a
+ * custom model class.
+ * @param ref A Firebase reference to bind the datasource to
+ * @param model A custom class that FDataSnapshots are coerced to, defaults to
+ * FDataSnapshot if nil
+ * @param nibName The name of a xib file to create the layout for a
+ * UICollectionViewCell
+ * @param identifier A string to use as a CellReuseIdentifier
+ * @param collectionView An instance of a UICollectionView to bind to
+ * @param options Options for the FirebaseCollectionViewDataSource
+ * @return An instance of FirebaseCollectionViewDataSource that populates a
+ * custom xib with a custom
+ * model class
+ */
+- (__NON_NULL instancetype)initWithRef:(__NON_NULL Firebase *)ref
+                            modelClass:(__NULLABLE Class)model
+                              nibNamed:(__NON_NULL NSString *)nibName
+                   cellReuseIdentifier:(__NON_NULL NSString *)identifier
+                                  view:(__NON_NULL UICollectionView *)collectionView
+                               options:(FirebaseUIOptions)options;
+
+/**
  * Initialize an instance of FirebaseCollectionViewDataSource that populates
  * UICollectionViewCells
  * with FDataSnapshots.
@@ -402,6 +449,53 @@
                                 nibNamed:(__NON_NULL NSString *)nibName
                      cellReuseIdentifier:(__NON_NULL NSString *)identifier
                                     view:(__NON_NULL UICollectionView *)collectionView;
+
+/**
+ * Initialize an instance of FirebaseCollectionViewDataSource that populates a
+ * custom subclass of
+ * UICollectionViewCell with a custom model class.
+ * @param query A Firebase query to bind the datasource to
+ * @param model A custom class that FDataSnapshots are coerced to, defaults to
+ * FDataSnapshot if nil
+ * @param cell A subclass of UICollectionViewCell used to populate the
+ * UICollectionView, defaults to
+ * UICollectionViewCell if nil
+ * @param identifier A string to use as a CellReuseIdentifier
+ * @param collectionView An instance of a UICollectionView to bind to
+ * *param options Options for FirebaseCollectionViewDataSource.
+ * @return An instance of FirebaseCollectionViewDataSource that populates a
+ * custom subclass of
+ * UICollectionViewCell with a custom model class
+ */
+- (__NON_NULL instancetype)initWithQuery:(__NON_NULL FQuery *)query
+                              modelClass:(__NULLABLE Class)model
+                               cellClass:(__NULLABLE Class)cell
+                     cellReuseIdentifier:(__NON_NULL NSString *)identifier
+                                    view:(__NON_NULL UICollectionView *)collectionView
+                                 options:(FirebaseUIOptions)options;
+
+/**
+ * Initialize an instance of FirebaseCollectionViewDataSource that populates a
+ * custom xib with a
+ * custom model class.
+ * @param query A Firebase query to bind the datasource to
+ * @param model A custom class that FDataSnapshots are coerced to, defaults to
+ * FDataSnapshot if nil
+ * @param nibName The name of a xib file to create the layout for a
+ * UICollectionViewCell
+ * @param identifier A string to use as a CellReuseIdentifier
+ * @param collectionView An instance of a UICollectionView to bind to
+ * @param options Options for the FirebaseCollectionViewDataSource.
+ * @return An instance of FirebaseCollectionViewDataSource that populates a
+ * custom xib with a custom
+ * model class
+ */
+- (__NON_NULL instancetype)initWithQuery:(__NON_NULL FQuery *)query
+                              modelClass:(__NULLABLE Class)model
+                                nibNamed:(__NON_NULL NSString *)nibName
+                     cellReuseIdentifier:(__NON_NULL NSString *)identifier
+                                    view:(__NON_NULL UICollectionView *)collectionView
+                                 options:(FirebaseUIOptions)options;
 
 /**
  * This method populates the fields of a UICollectionViewCell or subclass given

--- a/FirebaseUI/Core/API/FirebaseTableViewDataSource.h
+++ b/FirebaseUI/Core/API/FirebaseTableViewDataSource.h
@@ -241,6 +241,53 @@
                                   view:(__NON_NULL UITableView *)tableView;
 
 /**
+ * Initialize an instance of FirebaseTableViewDataSource that populates a custom
+ * subclass of
+ * UITableViewCell with a custom model class.
+ * @param ref A Firebase reference to bind the datasource to
+ * @param model A custom class that FDataSnapshots are coerced to, defaults to
+ * FDataSnapshot if nil
+ * @param cell A subclass of UITableViewCell used to populate the UITableView,
+ * defaults to
+ * UITableViewCell if nil
+ * @param identifier A string to use as a CellReuseIdentifier
+ * @param tableView An instance of a UITableView to bind to
+ * @param options Options for the FirebaseTableViewDataSource
+ * @return An instance of FirebaseTableViewDataSource that populates a custom
+ * subclass of
+ * UITableViewCell with a custom model class
+ */
+- (__NON_NULL instancetype)initWithRef:(__NON_NULL Firebase *)ref
+                            modelClass:(__NULLABLE Class)model
+                             cellClass:(__NULLABLE Class)cell
+                   cellReuseIdentifier:(__NON_NULL NSString *)identifier
+                                  view:(__NON_NULL UITableView *)tableView
+                               options:(FirebaseUIOptions)options;
+
+/**
+ * Initialize an instance of FirebaseTableViewDataSource that populates a custom
+ * xib with a custom
+ * model class.
+ * @param ref A Firebase reference to bind the datasource to
+ * @param model A custom class that FDataSnapshots are coerced to, defaults to
+ * FDataSnapshot if nil
+ * @param nibName The name of a xib file to create the layout for a
+ * UITableViewCell
+ * @param identifier A string to use as a CellReuseIdentifier
+ * @param tableView An instance of a UITableView to bind to
+ * @param options Options for the FirebaseTableViewDataSource
+ * @return An instance of FirebaseTableViewDataSource that populates a custom
+ * xib with a custom
+ * model class
+ */
+- (__NON_NULL instancetype)initWithRef:(__NON_NULL Firebase *)ref
+                            modelClass:(__NULLABLE Class)model
+                              nibNamed:(__NON_NULL NSString *)nibName
+                   cellReuseIdentifier:(__NON_NULL NSString *)identifier
+                                  view:(__NON_NULL UITableView *)tableView
+                               options:(FirebaseUIOptions)options;
+
+/**
  * Initialize an instance of FirebaseTableViewDataSource that populates
  * UITableViewCells with
  * FDataSnapshots.
@@ -390,7 +437,52 @@
                      cellReuseIdentifier:(__NON_NULL NSString *)identifier
                                     view:(__NON_NULL UITableView *)tableView;
 
+/**
+ * Initialize an instance of FirebaseTableViewDataSource that populates a custom
+ * subclass of
+ * UITableViewCell with a custom model class.
+ * @param query A Firebase query to bind the datasource to
+ * @param model A custom class that FDataSnapshots are coerced to, defaults to
+ * FDataSnapshot if nil
+ * @param cell A subclass of UITableViewCell used to populate the UITableView,
+ * defaults to
+ * UITableViewCell if nil
+ * @param identifier A string to use as a CellReuseIdentifier
+ * @param tableView An instance of a UITableView to bind to
+ * @param options Options for the FirebaseTableViewDataSource
+ * @return An instance of FirebaseTableViewDataSource that populates a custom
+ * subclass of
+ * UITableViewCell with a custom model class
+ */
+- (__NON_NULL instancetype)initWithQuery:(__NON_NULL FQuery *)query
+                              modelClass:(__NULLABLE Class)model
+                               cellClass:(__NULLABLE Class)cell
+                     cellReuseIdentifier:(__NON_NULL NSString *)identifier
+                                    view:(__NON_NULL UITableView *)tableView
+                                 options:(FirebaseUIOptions)options;
 
+/**
+ * Initialize an instance of FirebaseTableViewDataSource that populates a custom
+ * xib with a custom
+ * model class.
+ * @param query A Firebase query to bind the datasource to
+ * @param model A custom class that FDataSnapshots are coerced to, defaults to
+ * FDataSnapshot if nil
+ * @param nibName The name of a xib file to create the layout for a
+ * UITableViewCell
+ * @param identifier A string to use as a CellReuseIdentifier
+ * @param tableView An instance of a UITableView to bind to
+ * @param options Options for the FirebaseTableViewDataSource
+ * @return An instance of FirebaseTableViewDataSource that populates a custom
+ * xib with a custom
+ * model class
+ */
+- (__NON_NULL instancetype)initWithQuery:(__NON_NULL FQuery *)query
+                              modelClass:(__NULLABLE Class)model
+                                nibNamed:(__NON_NULL NSString *)nibName
+                     cellReuseIdentifier:(__NON_NULL NSString *)identifier
+                                    view:(__NON_NULL UITableView *)tableView
+                                 options:(FirebaseUIOptions)options;
 
 /**
  * This method populates the fields of a UITableViewCell or subclass given a

--- a/FirebaseUI/Core/API/FirebaseUIOptions.h
+++ b/FirebaseUI/Core/API/FirebaseUIOptions.h
@@ -1,0 +1,12 @@
+//
+//  FirebaseUIOptions.h
+//  FirebaseUI
+//
+//  Created by Chris Ellsworth on 12/5/15.
+//  Copyright © 2015 Firebase, Inc. All rights reserved.
+//
+
+typedef NS_OPTIONS(NSUInteger, FirebaseUIOptions) {
+  FirebaseUIOptionsNone = 0,
+  FirebaseUIOptionsResftulFallback = 1 << 0
+};

--- a/FirebaseUI/Core/Implementation/FRestDataSnapshot.m
+++ b/FirebaseUI/Core/Implementation/FRestDataSnapshot.m
@@ -1,0 +1,34 @@
+//
+//  FRestDataSnapshot.m
+//  FirebaseUI
+//
+//  Created by Chris Ellsworth on 12/5/15.
+//  Copyright © 2015 Firebase, Inc. All rights reserved.
+//
+
+#import "FRestDataSnapshot.h"
+
+@interface FRestDataSnapshot ()
+@property(nonatomic, strong) Firebase *refInternal;
+@property(nonatomic, strong) id valueInternal;
+@end
+
+@implementation FRestDataSnapshot
+
+- (instancetype)initWithRef:(Firebase *)ref value:(id)value {
+  if (self = [super init]) {
+    self.refInternal = ref;
+    self.valueInternal = value;
+  }
+  return self;
+}
+
+- (Firebase *)ref {
+  return self.refInternal;
+}
+
+- (id)value {
+  return self.valueInternal;
+}
+
+@end

--- a/FirebaseUI/Core/Implementation/FirebaseCollectionViewDataSource.m
+++ b/FirebaseUI/Core/Implementation/FirebaseCollectionViewDataSource.m
@@ -43,19 +43,19 @@
         cellReuseIdentifier:(NSString *)identifier
                        view:(UICollectionView *)collectionView {
   return [self initWithQuery:ref
-                modelClass:nil
-                 cellClass:nil
-       cellReuseIdentifier:identifier
-                      view:collectionView];
+                  modelClass:nil
+                   cellClass:nil
+         cellReuseIdentifier:identifier
+                        view:collectionView];
 }
 
 - (instancetype)initWithRef:(Firebase *)ref
    prototypeReuseIdentifier:(NSString *)identifier
                        view:(UICollectionView *)collectionView {
   return [self initWithQuery:ref
-                modelClass:nil
-    prototypeReuseIdentifier:identifier
-                      view:collectionView];
+                    modelClass:nil
+      prototypeReuseIdentifier:identifier
+                          view:collectionView];
 }
 
 - (instancetype)initWithRef:(Firebase *)ref
@@ -63,10 +63,10 @@
         cellReuseIdentifier:(NSString *)identifier
                        view:(UICollectionView *)collectionView {
   return [self initWithQuery:ref
-                modelClass:nil
-                 cellClass:cell
-       cellReuseIdentifier:identifier
-                      view:collectionView];
+                  modelClass:nil
+                   cellClass:cell
+         cellReuseIdentifier:identifier
+                        view:collectionView];
 }
 
 - (instancetype)initWithRef:(Firebase *)ref
@@ -74,10 +74,10 @@
         cellReuseIdentifier:(NSString *)identifier
                        view:(UICollectionView *)collectionView {
   return [self initWithQuery:ref
-                modelClass:nil
-                  nibNamed:nibName
-       cellReuseIdentifier:identifier
-                      view:collectionView];
+                  modelClass:nil
+                    nibNamed:nibName
+         cellReuseIdentifier:identifier
+                        view:collectionView];
 }
 
 - (instancetype)initWithRef:(Firebase *)ref
@@ -85,10 +85,10 @@
         cellReuseIdentifier:(NSString *)identifier
                        view:(UICollectionView *)collectionView {
   return [self initWithQuery:ref
-                modelClass:model
-                 cellClass:nil
-       cellReuseIdentifier:identifier
-                      view:collectionView];
+                  modelClass:model
+                   cellClass:nil
+         cellReuseIdentifier:identifier
+                        view:collectionView];
 }
 
 - (instancetype)initWithRef:(Firebase *)ref
@@ -96,9 +96,9 @@
    prototypeReuseIdentifier:(NSString *)identifier
                        view:(UICollectionView *)collectionView {
   return [self initWithQuery:ref
-                modelClass:model
-                 prototypeReuseIdentifier:identifier
-                      view:collectionView];
+                    modelClass:model
+      prototypeReuseIdentifier:identifier
+                          view:collectionView];
 }
 
 - (instancetype)initWithRef:(Firebase *)ref
@@ -110,7 +110,8 @@
                   modelClass:model
                    cellClass:cell
          cellReuseIdentifier:identifier
-                        view:collectionView];
+                        view:collectionView
+                     options:FirebaseUIOptionsNone];
 }
 
 - (instancetype)initWithRef:(Firebase *)ref
@@ -122,17 +123,46 @@
                   modelClass:model
                     nibNamed:nibName
          cellReuseIdentifier:identifier
-                        view:collectionView];
+                        view:collectionView
+                     options:FirebaseUIOptionsNone];
+}
+
+- (instancetype)initWithRef:(Firebase *)ref
+                 modelClass:(Class)model
+                  cellClass:(Class)cell
+        cellReuseIdentifier:(NSString *)identifier
+                       view:(UICollectionView *)collectionView
+                    options:(FirebaseUIOptions)options {
+  return [self initWithQuery:ref
+                  modelClass:model
+                   cellClass:cell
+         cellReuseIdentifier:identifier
+                        view:collectionView
+                     options:options];
+}
+
+- (instancetype)initWithRef:(Firebase *)ref
+                 modelClass:(Class)model
+                   nibNamed:(NSString *)nibName
+        cellReuseIdentifier:(NSString *)identifier
+                       view:(UICollectionView *)collectionView
+                    options:(FirebaseUIOptions)options {
+  return [self initWithQuery:ref
+                  modelClass:model
+                    nibNamed:nibName
+         cellReuseIdentifier:identifier
+                        view:collectionView
+                     options:options];
 }
 
 - (instancetype)initWithQuery:(FQuery *)query
-        cellReuseIdentifier:(NSString *)identifier
-                       view:(UICollectionView *)collectionView {
+          cellReuseIdentifier:(NSString *)identifier
+                         view:(UICollectionView *)collectionView {
   return [self initWithQuery:query
-                modelClass:nil
-                 cellClass:nil
-       cellReuseIdentifier:identifier
-                      view:collectionView];
+                  modelClass:nil
+                   cellClass:nil
+         cellReuseIdentifier:identifier
+                        view:collectionView];
 }
 
 - (instancetype)initWithQuery:(FQuery *)query
@@ -192,10 +222,37 @@
 }
 
 - (instancetype)initWithQuery:(FQuery *)query
-                 modelClass:(Class)model
-                  cellClass:(Class)cell
-        cellReuseIdentifier:(NSString *)identifier
-                       view:(UICollectionView *)collectionView {
+                   modelClass:(Class)model
+                    cellClass:(Class)cell
+          cellReuseIdentifier:(NSString *)identifier
+                         view:(UICollectionView *)collectionView {
+  return [self initWithQuery:query
+                  modelClass:model
+                   cellClass:cell
+         cellReuseIdentifier:identifier
+                        view:collectionView
+                     options:FirebaseUIOptionsNone];
+}
+
+- (instancetype)initWithQuery:(FQuery *)query
+                   modelClass:(Class)model
+                     nibNamed:(NSString *)nibName
+          cellReuseIdentifier:(NSString *)identifier
+                         view:(UICollectionView *)collectionView {
+  return [self initWithQuery:query
+                  modelClass:model
+                    nibNamed:nibName
+         cellReuseIdentifier:identifier
+                        view:collectionView
+                     options:FirebaseUIOptionsNone];
+}
+
+- (instancetype)initWithQuery:(FQuery *)query
+                   modelClass:(Class)model
+                    cellClass:(Class)cell
+          cellReuseIdentifier:(NSString *)identifier
+                         view:(UICollectionView *)collectionView
+                      options:(FirebaseUIOptions)options {
   FirebaseArray *array = [[FirebaseArray alloc] initWithQuery:query];
   self = [super initWithArray:array];
   if (self) {
@@ -223,10 +280,11 @@
 }
 
 - (instancetype)initWithQuery:(FQuery *)query
-                 modelClass:(Class)model
-                   nibNamed:(NSString *)nibName
-        cellReuseIdentifier:(NSString *)identifier
-                       view:(UICollectionView *)collectionView {
+                   modelClass:(Class)model
+                     nibNamed:(NSString *)nibName
+          cellReuseIdentifier:(NSString *)identifier
+                         view:(UICollectionView *)collectionView
+                      options:(FirebaseUIOptions)options {
   FirebaseArray *array = [[FirebaseArray alloc] initWithQuery:query];
   self = [super initWithArray:array];
   if (self) {
@@ -267,6 +325,10 @@
 - (void)childMoved:(id)obj fromIndex:(NSUInteger)fromIndex toIndex:(NSUInteger)toIndex {
   [self.collectionView moveItemAtIndexPath:[NSIndexPath indexPathForRow:fromIndex inSection:0]
                                toIndexPath:[NSIndexPath indexPathForRow:toIndex inSection:0]];
+}
+
+- (void)dataReloaded {
+  [self.collectionView reloadData];
 }
 
 #pragma mark -

--- a/FirebaseUI/Core/Implementation/FirebaseTableViewDataSource.m
+++ b/FirebaseUI/Core/Implementation/FirebaseTableViewDataSource.m
@@ -43,20 +43,22 @@
         cellReuseIdentifier:(NSString *)identifier
                        view:(UITableView *)tableView {
   return [self initWithQuery:ref
-                modelClass:nil
-                 cellClass:nil
-       cellReuseIdentifier:identifier
-                      view:tableView];
+                  modelClass:nil
+                   cellClass:nil
+         cellReuseIdentifier:identifier
+                        view:tableView
+                     options:FirebaseUIOptionsNone];
 }
 
 - (instancetype)initWithRef:(Firebase *)ref
    prototypeReuseIdentifier:(NSString *)identifier
                        view:(UITableView *)tableView {
   return [self initWithQuery:ref
-                modelClass:nil
-                 cellClass:nil
-       cellReuseIdentifier:identifier
-                      view:tableView];
+                  modelClass:nil
+                   cellClass:nil
+         cellReuseIdentifier:identifier
+                        view:tableView
+                     options:FirebaseUIOptionsNone];
 }
 
 - (instancetype)initWithRef:(Firebase *)ref
@@ -64,10 +66,11 @@
         cellReuseIdentifier:(NSString *)identifier
                        view:(UITableView *)tableView {
   return [self initWithQuery:ref
-                modelClass:nil
-                 cellClass:cell
-       cellReuseIdentifier:identifier
-                      view:tableView];
+                  modelClass:nil
+                   cellClass:cell
+         cellReuseIdentifier:identifier
+                        view:tableView
+                     options:FirebaseUIOptionsNone];
 }
 
 - (instancetype)initWithRef:(Firebase *)ref
@@ -75,10 +78,11 @@
         cellReuseIdentifier:(NSString *)identifier
                        view:(UITableView *)tableView {
   return [self initWithQuery:ref
-                modelClass:nil
-                  nibNamed:nibName
-       cellReuseIdentifier:identifier
-                      view:tableView];
+                  modelClass:nil
+                    nibNamed:nibName
+         cellReuseIdentifier:identifier
+                        view:tableView
+                     options:FirebaseUIOptionsNone];
 }
 
 - (instancetype)initWithRef:(Firebase *)ref
@@ -86,10 +90,11 @@
         cellReuseIdentifier:(NSString *)identifier
                        view:(UITableView *)tableView {
   return [self initWithQuery:ref
-                modelClass:model
-                 cellClass:nil
-       cellReuseIdentifier:identifier
-                      view:tableView];
+                  modelClass:model
+                   cellClass:nil
+         cellReuseIdentifier:identifier
+                        view:tableView
+                     options:FirebaseUIOptionsNone];
 }
 
 - (instancetype)initWithRef:(Firebase *)ref
@@ -97,10 +102,11 @@
    prototypeReuseIdentifier:(NSString *)identifier
                        view:(UITableView *)tableView {
   return [self initWithQuery:ref
-                modelClass:model
-                 cellClass:nil
-       cellReuseIdentifier:identifier
-                      view:tableView];
+                  modelClass:model
+                   cellClass:nil
+         cellReuseIdentifier:identifier
+                        view:tableView
+                     options:FirebaseUIOptionsNone];
 }
 
 - (instancetype)initWithRef:(Firebase *)ref
@@ -111,8 +117,9 @@
   return [self initWithQuery:ref
                   modelClass:model
                    cellClass:cell
-          cellReuseIdentifier:identifier
-                        view:tableView];
+         cellReuseIdentifier:identifier
+                        view:tableView
+                     options:FirebaseUIOptionsNone];
 }
 
 - (instancetype)initWithRef:(Firebase *)ref
@@ -121,10 +128,39 @@
         cellReuseIdentifier:(NSString *)identifier
                        view:(UITableView *)tableView {
   return [self initWithQuery:ref
-           modelClass:model
-            nibNamed:nibName
-  cellReuseIdentifier:identifier
-                 view:tableView];
+                  modelClass:model
+                    nibNamed:nibName
+         cellReuseIdentifier:identifier
+                        view:tableView
+                     options:FirebaseUIOptionsNone];
+}
+
+- (instancetype)initWithRef:(Firebase *)ref
+                 modelClass:(Class)model
+                  cellClass:(Class)cell
+        cellReuseIdentifier:(NSString *)identifier
+                       view:(UITableView *)tableView
+                    options:(FirebaseUIOptions)options {
+  return [self initWithQuery:ref
+                  modelClass:model
+                   cellClass:cell
+         cellReuseIdentifier:identifier
+                        view:tableView
+                     options:options];
+}
+
+- (instancetype)initWithRef:(Firebase *)ref
+                 modelClass:(Class)model
+                   nibNamed:(NSString *)nibName
+        cellReuseIdentifier:(NSString *)identifier
+                       view:(UITableView *)tableView
+                    options:(FirebaseUIOptions)options {
+  return [self initWithQuery:ref
+                  modelClass:model
+                    nibNamed:nibName
+         cellReuseIdentifier:identifier
+                        view:tableView
+                     options:options];
 }
 
 - (instancetype)initWithQuery:(FQuery *)query
@@ -198,7 +234,34 @@
                     cellClass:(Class)cell
           cellReuseIdentifier:(NSString *)identifier
                          view:(UITableView *)tableView {
-  FirebaseArray *array = [[FirebaseArray alloc] initWithQuery:query];
+  return [self initWithQuery:query
+                  modelClass:model
+                   cellClass:cell
+         cellReuseIdentifier:identifier
+                        view:tableView
+                     options:FirebaseUIOptionsNone];
+}
+
+- (instancetype)initWithQuery:(FQuery *)query
+                   modelClass:(Class)model
+                     nibNamed:(NSString *)nibName
+          cellReuseIdentifier:(NSString *)identifier
+                         view:(UITableView *)tableView {
+  return [self initWithQuery:query
+                  modelClass:model
+                    nibNamed:nibName
+         cellReuseIdentifier:identifier
+                        view:tableView
+                     options:FirebaseUIOptionsNone];
+}
+
+- (instancetype)initWithQuery:(FQuery *)query
+                   modelClass:(Class)model
+                    cellClass:(Class)cell
+          cellReuseIdentifier:(NSString *)identifier
+                         view:(UITableView *)tableView
+                      options:(FirebaseUIOptions)options {
+  FirebaseArray *array = [[FirebaseArray alloc] initWithQuery:query options:options];
   self = [super initWithArray:array];
   if (self) {
     if (!model) {
@@ -226,8 +289,9 @@
                    modelClass:(Class)model
                      nibNamed:(NSString *)nibName
           cellReuseIdentifier:(NSString *)identifier
-                         view:(UITableView *)tableView {
-  FirebaseArray *array = [[FirebaseArray alloc] initWithQuery:query];
+                         view:(UITableView *)tableView
+                      options:(FirebaseUIOptions)options {
+  FirebaseArray *array = [[FirebaseArray alloc] initWithQuery:query options:options];
   self = [super initWithArray:array];
   if (self) {
     if (!model) {
@@ -277,6 +341,10 @@
   [self.tableView moveRowAtIndexPath:[NSIndexPath indexPathForRow:fromIndex inSection:0]
                          toIndexPath:[NSIndexPath indexPathForRow:toIndex inSection:0]];
   [self.tableView endUpdates];
+}
+
+- (void)dataReloaded {
+  [self.tableView reloadData];
 }
 
 #pragma mark -


### PR DESCRIPTION
Optionally (via `FirebaseUIOptions` parameter) fall back to RESTful fetch (with `shallow=true`) when the backing dataset is too large for the websockets API. Will auth if necessary. Can probably do some fancier things with different query parameters for ordering/filtering in the future.

There are quite a lot of constructors for the data sources now.

Is there a better way to populate an `FDataSnapshot` than subclassing it and overriding methods?
