### PR TITLE
FirebaseSet

### DIFF
--- a/FirebaseUI.xcodeproj/project.pbxproj
+++ b/FirebaseUI.xcodeproj/project.pbxproj
@@ -24,7 +24,6 @@
 /* Begin PBXBuildFile section */
 		BB372B551B8BE4890046905E /* FirebaseTwitterAuthProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = BB372B541B8BE4890046905E /* FirebaseTwitterAuthProvider.m */; };
 		BB372B601B8D1B580046905E /* FirebaseTwitterAuthProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = BB372B531B8BE4510046905E /* FirebaseTwitterAuthProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BB4877901BA8A0C000FD3D4D /* GoogleSignIn.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BB48778F1BA8A0C000FD3D4D /* GoogleSignIn.framework */; };
 		BB48779B1BA8A0D600FD3D4D /* Core.h in Headers */ = {isa = PBXBuildFile; fileRef = BB4877931BA8A0D600FD3D4D /* Core.h */; };
 		BB48779C1BA8A0D600FD3D4D /* GGLConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = BB4877941BA8A0D600FD3D4D /* GGLConfiguration.h */; };
 		BB48779D1BA8A0D600FD3D4D /* GGLContext.h in Headers */ = {isa = PBXBuildFile; fileRef = BB4877951BA8A0D600FD3D4D /* GGLContext.h */; };
@@ -40,6 +39,17 @@
 		BBF6D4161BA19CDF00C644A7 /* FirebaseFacebookAuthProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = BB6AC2131BA06AC300A10461 /* FirebaseFacebookAuthProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BBF6D41B1BA1FFAD00C644A7 /* FirebaseGoogleAuthProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = BBF6D41A1BA1FFAD00C644A7 /* FirebaseGoogleAuthProvider.m */; };
 		BBF6D5771BA345E600C644A7 /* FirebaseAuthProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = BBF6D5761BA33AC300C644A7 /* FirebaseAuthProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BFC897DA1C1772CC00A71F19 /* FirebaseSet.h in Headers */ = {isa = PBXBuildFile; fileRef = BFC897D31C1772CC00A71F19 /* FirebaseSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BFC897DB1C1772CC00A71F19 /* FirebaseSetDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = BFC897D41C1772CC00A71F19 /* FirebaseSetDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BFC897DC1C1772CC00A71F19 /* FirebaseSetObject.h in Headers */ = {isa = PBXBuildFile; fileRef = BFC897D51C1772CC00A71F19 /* FirebaseSetObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BFC897DD1C1772CC00A71F19 /* FirebaseSortedData.h in Headers */ = {isa = PBXBuildFile; fileRef = BFC897D61C1772CC00A71F19 /* FirebaseSortedData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BFC897DE1C1772CC00A71F19 /* FirebaseSortedDataDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = BFC897D71C1772CC00A71F19 /* FirebaseSortedDataDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BFC897DF1C1772CC00A71F19 /* FirebaseSortedDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = BFC897D81C1772CC00A71F19 /* FirebaseSortedDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BFC897E01C1772CC00A71F19 /* FirebaseSortedTableViewDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = BFC897D91C1772CC00A71F19 /* FirebaseSortedTableViewDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BFC897E51C1772E000A71F19 /* FirebaseSet.m in Sources */ = {isa = PBXBuildFile; fileRef = BFC897E11C1772E000A71F19 /* FirebaseSet.m */; };
+		BFC897E61C1772E000A71F19 /* FirebaseSortedData.m in Sources */ = {isa = PBXBuildFile; fileRef = BFC897E21C1772E000A71F19 /* FirebaseSortedData.m */; };
+		BFC897E71C1772E000A71F19 /* FirebaseSortedDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = BFC897E31C1772E000A71F19 /* FirebaseSortedDataSource.m */; };
+		BFC897E81C1772E000A71F19 /* FirebaseSortedTableViewDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = BFC897E41C1772E000A71F19 /* FirebaseSortedTableViewDataSource.m */; };
 		D809A11E1BF67095000257AA /* FirebaseAuthConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = D809A11D1BF67095000257AA /* FirebaseAuthConstants.m */; };
 		D809A1271BF6FF6C000257AA /* FirebaseLoginViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = D809A1241BF6FF6C000257AA /* FirebaseLoginViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D809A1311BF7ECB0000257AA /* FirebaseLoginViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D809A1301BF7ECB0000257AA /* FirebaseLoginViewController.m */; };
@@ -60,7 +70,7 @@
 		D81495FF1BF5AF460099AE10 /* FirebaseTableViewDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = D81495FA1BF5AF460099AE10 /* FirebaseTableViewDataSource.m */; };
 		D81496061BF5B92C0099AE10 /* FirebasePasswordAuthProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = D81496051BF5B92C0099AE10 /* FirebasePasswordAuthProvider.m */; };
 		D81496071BF5B9BE0099AE10 /* FirebasePasswordAuthProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = D81496041BF5B9110099AE10 /* FirebasePasswordAuthProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D8680D901C0631FD001987EB /* FirebaseAuthDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = D8680D8F1C0631FD001987EB /* FirebaseAuthDelegate.h */; };
+		D8680D901C0631FD001987EB /* FirebaseAuthDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = D8680D8F1C0631FD001987EB /* FirebaseAuthDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D87943371BF51FF000525DFD /* FirebaseAuthProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = D87943361BF51FF000525DFD /* FirebaseAuthProvider.m */; };
 		D87943461BF59E1F00525DFD /* FirebaseAuthConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = D879433E1BF5654000525DFD /* FirebaseAuthConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D87943471BF59E4F00525DFD /* TwitterAuthDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = D879433D1BF5593800525DFD /* TwitterAuthDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -95,7 +105,6 @@
 /* Begin PBXFileReference section */
 		BB372B531B8BE4510046905E /* FirebaseTwitterAuthProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FirebaseTwitterAuthProvider.h; path = Auth/API/FirebaseTwitterAuthProvider.h; sourceTree = "<group>"; };
 		BB372B541B8BE4890046905E /* FirebaseTwitterAuthProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FirebaseTwitterAuthProvider.m; path = Auth/Implementation/FirebaseTwitterAuthProvider.m; sourceTree = "<group>"; };
-		BB48778F1BA8A0C000FD3D4D /* GoogleSignIn.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleSignIn.framework; path = sdk/google_signin_sdk_2_2_0/GoogleSignIn.framework; sourceTree = "<group>"; };
 		BB4877931BA8A0D600FD3D4D /* Core.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Core.h; sourceTree = "<group>"; };
 		BB4877941BA8A0D600FD3D4D /* GGLConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GGLConfiguration.h; sourceTree = "<group>"; };
 		BB4877951BA8A0D600FD3D4D /* GGLContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GGLContext.h; sourceTree = "<group>"; };
@@ -111,6 +120,17 @@
 		BBF6D4191BA1FF9200C644A7 /* FirebaseGoogleAuthProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FirebaseGoogleAuthProvider.h; path = Auth/API/FirebaseGoogleAuthProvider.h; sourceTree = "<group>"; };
 		BBF6D41A1BA1FFAD00C644A7 /* FirebaseGoogleAuthProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FirebaseGoogleAuthProvider.m; path = Auth/Implementation/FirebaseGoogleAuthProvider.m; sourceTree = "<group>"; };
 		BBF6D5761BA33AC300C644A7 /* FirebaseAuthProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FirebaseAuthProvider.h; path = Auth/API/FirebaseAuthProvider.h; sourceTree = "<group>"; };
+		BFC897D31C1772CC00A71F19 /* FirebaseSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FirebaseSet.h; sourceTree = "<group>"; };
+		BFC897D41C1772CC00A71F19 /* FirebaseSetDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FirebaseSetDelegate.h; sourceTree = "<group>"; };
+		BFC897D51C1772CC00A71F19 /* FirebaseSetObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FirebaseSetObject.h; sourceTree = "<group>"; };
+		BFC897D61C1772CC00A71F19 /* FirebaseSortedData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FirebaseSortedData.h; sourceTree = "<group>"; };
+		BFC897D71C1772CC00A71F19 /* FirebaseSortedDataDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FirebaseSortedDataDelegate.h; sourceTree = "<group>"; };
+		BFC897D81C1772CC00A71F19 /* FirebaseSortedDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FirebaseSortedDataSource.h; sourceTree = "<group>"; };
+		BFC897D91C1772CC00A71F19 /* FirebaseSortedTableViewDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FirebaseSortedTableViewDataSource.h; sourceTree = "<group>"; };
+		BFC897E11C1772E000A71F19 /* FirebaseSet.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FirebaseSet.m; sourceTree = "<group>"; };
+		BFC897E21C1772E000A71F19 /* FirebaseSortedData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FirebaseSortedData.m; sourceTree = "<group>"; };
+		BFC897E31C1772E000A71F19 /* FirebaseSortedDataSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FirebaseSortedDataSource.m; sourceTree = "<group>"; };
+		BFC897E41C1772E000A71F19 /* FirebaseSortedTableViewDataSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FirebaseSortedTableViewDataSource.m; sourceTree = "<group>"; };
 		D809A11D1BF67095000257AA /* FirebaseAuthConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FirebaseAuthConstants.m; path = Auth/Implementation/FirebaseAuthConstants.m; sourceTree = "<group>"; };
 		D809A1241BF6FF6C000257AA /* FirebaseLoginViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FirebaseLoginViewController.h; path = Auth/API/FirebaseLoginViewController.h; sourceTree = "<group>"; };
 		D809A1301BF7ECB0000257AA /* FirebaseLoginViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FirebaseLoginViewController.m; path = Auth/Implementation/FirebaseLoginViewController.m; sourceTree = "<group>"; };
@@ -148,7 +168,6 @@
 			files = (
 				D809A1721BFCF23B000257AA /* Accounts.framework in Frameworks */,
 				BB62DD071BA6F01E001BD539 /* FBSDKCoreKit.framework in Frameworks */,
-				BB4877901BA8A0C000FD3D4D /* GoogleSignIn.framework in Frameworks */,
 				BB62DD081BA6F01E001BD539 /* FBSDKLoginKit.framework in Frameworks */,
 				D8124F441B72C94E003441AD /* Firebase.framework in Frameworks */,
 				D8B6ACE51B58383C005CDDB2 /* UIKit.framework in Frameworks */,
@@ -265,7 +284,6 @@
 				D809A1711BFCF23B000257AA /* Accounts.framework */,
 				BB4877911BA8A0D600FD3D4D /* GGLCore */,
 				BB4877971BA8A0D600FD3D4D /* GGLSignIn */,
-				BB48778F1BA8A0C000FD3D4D /* GoogleSignIn.framework */,
 				BB62DD051BA6F01E001BD539 /* FBSDKCoreKit.framework */,
 				BB62DD061BA6F01E001BD539 /* FBSDKLoginKit.framework */,
 				D8124F401B72A90C003441AD /* Firebase.framework */,
@@ -283,6 +301,13 @@
 				D81495ED1BF5AF280099AE10 /* FirebaseCollectionViewDataSource.h */,
 				D81495EE1BF5AF280099AE10 /* FirebaseDataSource.h */,
 				D81495EF1BF5AF280099AE10 /* FirebaseTableViewDataSource.h */,
+				BFC897D31C1772CC00A71F19 /* FirebaseSet.h */,
+				BFC897D41C1772CC00A71F19 /* FirebaseSetDelegate.h */,
+				BFC897D51C1772CC00A71F19 /* FirebaseSetObject.h */,
+				BFC897D61C1772CC00A71F19 /* FirebaseSortedData.h */,
+				BFC897D71C1772CC00A71F19 /* FirebaseSortedDataDelegate.h */,
+				BFC897D81C1772CC00A71F19 /* FirebaseSortedDataSource.h */,
+				BFC897D91C1772CC00A71F19 /* FirebaseSortedTableViewDataSource.h */,
 			);
 			name = API;
 			sourceTree = "<group>";
@@ -294,6 +319,10 @@
 				D81495F81BF5AF460099AE10 /* FirebaseCollectionViewDataSource.m */,
 				D81495F91BF5AF460099AE10 /* FirebaseDataSource.m */,
 				D81495FA1BF5AF460099AE10 /* FirebaseTableViewDataSource.m */,
+				BFC897E11C1772E000A71F19 /* FirebaseSet.m */,
+				BFC897E21C1772E000A71F19 /* FirebaseSortedData.m */,
+				BFC897E31C1772E000A71F19 /* FirebaseSortedDataSource.m */,
+				BFC897E41C1772E000A71F19 /* FirebaseSortedTableViewDataSource.m */,
 			);
 			name = Implementation;
 			sourceTree = "<group>";
@@ -352,12 +381,19 @@
 				D81495F31BF5AF280099AE10 /* FirebaseCollectionViewDataSource.h in Headers */,
 				BB48779C1BA8A0D600FD3D4D /* GGLConfiguration.h in Headers */,
 				D81495F11BF5AF280099AE10 /* FirebaseArray.h in Headers */,
+				BFC897DE1C1772CC00A71F19 /* FirebaseSortedDataDelegate.h in Headers */,
+				BFC897DF1C1772CC00A71F19 /* FirebaseSortedDataSource.h in Headers */,
+				BFC897DC1C1772CC00A71F19 /* FirebaseSetObject.h in Headers */,
+				BFC897E01C1772CC00A71F19 /* FirebaseSortedTableViewDataSource.h in Headers */,
+				BFC897DD1C1772CC00A71F19 /* FirebaseSortedData.h in Headers */,
+				BFC897DA1C1772CC00A71F19 /* FirebaseSet.h in Headers */,
+				BFC897DB1C1772CC00A71F19 /* FirebaseSetDelegate.h in Headers */,
 				BB48779B1BA8A0D600FD3D4D /* Core.h in Headers */,
 				D879434A1BF5A41800525DFD /* XCodeMacros.h in Headers */,
 				BB4877A01BA8A0D600FD3D4D /* SignIn.h in Headers */,
 				BB372B601B8D1B580046905E /* FirebaseTwitterAuthProvider.h in Headers */,
-				BB48779F1BA8A0D600FD3D4D /* GGLContext+SignIn.h in Headers */,
 				D8680D901C0631FD001987EB /* FirebaseAuthDelegate.h in Headers */,
+				BB48779F1BA8A0D600FD3D4D /* GGLContext+SignIn.h in Headers */,
 				BBF6D4161BA19CDF00C644A7 /* FirebaseFacebookAuthProvider.h in Headers */,
 				D809A1271BF6FF6C000257AA /* FirebaseLoginViewController.h in Headers */,
 				D81496071BF5B9BE0099AE10 /* FirebasePasswordAuthProvider.h in Headers */,
@@ -475,17 +511,21 @@
 			files = (
 				D81495FD1BF5AF460099AE10 /* FirebaseCollectionViewDataSource.m in Sources */,
 				D81495FC1BF5AF460099AE10 /* FirebaseArray.m in Sources */,
+				BFC897E71C1772E000A71F19 /* FirebaseSortedDataSource.m in Sources */,
 				BB6AC2151BA06B6B00A10461 /* FirebaseFacebookAuthProvider.m in Sources */,
 				D809A1701BFBE5F9000257AA /* FirebaseLoginButton.m in Sources */,
 				D81495FE1BF5AF460099AE10 /* FirebaseDataSource.m in Sources */,
 				D87943371BF51FF000525DFD /* FirebaseAuthProvider.m in Sources */,
 				BB372B551B8BE4890046905E /* FirebaseTwitterAuthProvider.m in Sources */,
+				BFC897E51C1772E000A71F19 /* FirebaseSet.m in Sources */,
 				BB62DD0B1BA6F400001BD539 /* FirebaseAppDelegate.m in Sources */,
 				D809A1311BF7ECB0000257AA /* FirebaseLoginViewController.m in Sources */,
 				D81496061BF5B92C0099AE10 /* FirebasePasswordAuthProvider.m in Sources */,
 				D81495FF1BF5AF460099AE10 /* FirebaseTableViewDataSource.m in Sources */,
 				D809A11E1BF67095000257AA /* FirebaseAuthConstants.m in Sources */,
 				BBF6D41B1BA1FFAD00C644A7 /* FirebaseGoogleAuthProvider.m in Sources */,
+				BFC897E61C1772E000A71F19 /* FirebaseSortedData.m in Sources */,
+				BFC897E81C1772E000A71F19 /* FirebaseSortedTableViewDataSource.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FirebaseUI/FirebaseSet.h
+++ b/FirebaseUI/FirebaseSet.h
@@ -1,0 +1,124 @@
+//
+//  FirebaseSet.h
+//  FirebaseUI
+//
+//  Created by Zoe Van Brunt on 11/25/15.
+//  Copyright © 2015 Firebase, Inc. All rights reserved.
+//
+
+// clang-format on
+
+#import <Foundation/Foundation.h>
+
+#import "FirebaseSetDelegate.h"
+#import "FirebaseSetObject.h"
+#import "FirebaseSortedData.h"
+
+@class Firebase, FQuery, FDataSnapshot;
+
+/**
+ * FirebaseSet provides a set wrapper that is synchronized with a Firebase
+ * reference of query. It is useful for building custom data structures or 
+ * sources. A FirebaseSet can be used as a property to keep remote data in 
+ * memory, and then to pass into another data source for more performant 
+ * data accessibility.
+ */
+@interface FirebaseSet : NSObject
+
+/**
+ * The Firebase reference that provides data to populate the instance of 
+ * FirebaseSet.
+ */
+@property (nonatomic, strong) Firebase * ref;
+
+/**
+ * An immutable representation of the objects in the FirebaseSet.
+ */
+@property (nonatomic, strong, readonly) NSSet<id> * objects;
+
+/**
+ * @returns A new sorted data object for this FirebaseSet
+ */
+@property (nonatomic, readonly) FirebaseSortedData * sortedData;
+
+/**
+ * Returns true if the FirebaseSet has finished receiving all the initial
+ * updates. Updated when the first FEventTypeValue event fires.
+ */
+@property (nonatomic, readonly) BOOL initialValuesSet;
+
+/**
+ * How many objects are currently in the FirebaseSet.
+ */
+@property (nonatomic, readonly) NSUInteger count;
+
+/**
+ * Use this block to convert a snapshot into your custom class of choice.
+ * You must set this property before calling @p initiateObservers, if at all.
+ * If you set this property the @p FirebaseSet will return objects of your
+ * custom class instead of @p FDataSnapshots.
+ * @param snap The @p FDataSnapshot that you use to create your custom object.
+ * @warning Your custom class must conform to the @p FirebaseSetObject
+ * protocol.
+ * @warning Set this block before calling @p initiateObservers.
+ * @see FirebaseSetObject, FDataSnapshot
+ */
+@property (nonatomic, strong) id <FirebaseSetObject> (^classConversionBlock)(FDataSnapshot * snap);
+
+/**
+ * Use this block to customize handling of changes. If this block is not 
+ * set, the default behavior is to simply replace the original with the new
+ * one.
+ * @param snap The @p FDataSnapshot that represents the changed state of the
+ * object
+ * @param matchingObject the object that is being changed. If 
+ * @p classConversionBlock is not set, this is an @p FDataSnapshot.
+ * @return The changed object, usually @p matchingObject after applying changes.
+ * @see FirebaseSetObject, FDataSnapshot
+ */
+@property (nonatomic, strong) id <FirebaseSetObject> (^changeHandlerBlock)(FDataSnapshot * snap, id <FirebaseSetObject> matchingObject);
+
+#pragma mark Public API Methods
+
+/**
+ * Add a delegate object receiver.
+ * @param delegate a delegate object that changes are surfaced to, 
+ * which conforms to the @p FirebaseSetDelegate protocol.
+ * @see FirebaseSetDelegate
+ */
+- (void)addDelegate:(id <FirebaseSetDelegate>)delegate;
+
+/**
+ * Remove a delegate object so that it no longer receives delegate calls.
+ * @param delegate the delegate object to remove.
+ * @see FirebaseSetDelegate
+ */
+- (void)removeDelegate:(id <FirebaseSetDelegate>)delegate;
+
+/**
+ * Returns an object matching the supplied key.
+ * @param key The key to match, specified in the @p FirebaseSetObject
+ * protocol.
+ * @see FirebaseSetObject
+ */
+- (id <FirebaseSetObject>)objectMatchingKey:(NSString *)key;
+
+#pragma mark Initializer Methods
+
+/**
+ * Initializes @p FirebaseSet with a standard @p Firebase reference.
+ * @param ref The @p Firebase reference which provides data to @p FirebaseSet
+ * @return The instance of @p FirebaseSet
+ * @see Firebase
+ */
+- (instancetype)initWithRef:(Firebase *)ref;
+
+/**
+ * Begins all observers for the @p FirebaseSet. You must call this method in
+ * order for the @p FirebaseSet to begin any syncing.
+ * @warning If you wish to set @p classConversion and @p changeHander blocks, you
+ * must do so before calling this method.
+ */
+- (void)initiateObservers;
+
+@end

--- a/FirebaseUI/FirebaseSet.m
+++ b/FirebaseUI/FirebaseSet.m
@@ -1,0 +1,226 @@
+//
+//  FirebaseSet.m
+//  FirebaseUI
+//
+//  Created by Zoe Van Brunt on 11/25/15.
+//  Copyright © 2015 Firebase, Inc. All rights reserved.
+//
+
+#import "FirebaseSet.h"
+#import <Firebase/Firebase.h>
+
+@interface FirebaseSet ()
+
+@property (nonatomic) FirebaseHandle valueHandle;
+@property (nonatomic) FirebaseHandle addHandle;
+@property (nonatomic) FirebaseHandle removeHandle;
+@property (nonatomic) FirebaseHandle changeHandle;
+
+@property (nonatomic, strong) NSMapTable * table;
+@property (nonatomic, strong) NSMutableSet * mutableObjects;
+
+@property (nonatomic, strong) NSHashTable * delegates;
+
+@end
+
+@implementation FirebaseSet
+
+#pragma mark Initializer Methods
+
+- (instancetype)initWithRef:(Firebase *)ref;
+{
+    self = [self init];
+    
+    _ref = ref;
+    
+    return self;
+}
+
+- (instancetype)init
+{
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+    
+    _table = [NSMapTable mapTableWithKeyOptions:NSMapTableStrongMemory
+                                   valueOptions:NSMapTableWeakMemory];
+    
+    self.mutableObjects = [NSMutableSet set];
+    
+    self.delegates = [NSHashTable weakObjectsHashTable];
+    
+    return self;
+}
+
+- (void)dealloc;
+{
+    [self endAllObservers];
+}
+
+
+#pragma mark Public API Methods
+
+- (void)addDelegate:(id<FirebaseSetDelegate>)delegate;
+{
+    [self.delegates addObject:delegate];
+}
+
+- (void)removeDelegate:(id<FirebaseSetDelegate>)delegate;
+{
+    [self.delegates removeObject:delegate];
+}
+
+- (NSSet<id> *)objects;
+{
+    return [NSSet setWithSet:self.mutableObjects];
+}
+
+- (FirebaseSortedData *)sortedData;
+{
+    return [[FirebaseSortedData alloc] initWithFirebaseSet:self];
+}
+
+- (NSUInteger)count;
+{
+    return [self.mutableObjects count];
+}
+
+- (id<FirebaseSetObject>)objectMatchingKey:(NSString *)key;
+{
+    return [self.table objectForKey:key];
+}
+
+#pragma mark Private API Methods
+
+- (id)prepareSnapshot:(FDataSnapshot *)snapshot;
+{
+    id object;
+    
+    if (self.classConversionBlock) {
+        object = self.classConversionBlock(snapshot);
+    } else {
+        object = snapshot;
+    }
+    
+    return object;
+}
+
+#pragma mark Observer Methods
+
+- (void)initiateObservers;
+{
+    if (self.addHandle && self.removeHandle && self.changeHandle && self.valueHandle) {
+        return;
+    }
+    FirebaseSet __weak * welf = self;
+    
+    self.addHandle = [self.ref observeEventType:FEventTypeChildAdded
+                                      withBlock:^(FDataSnapshot *snapshot) {
+                                          [welf handleAdd:snapshot];
+                                      }];
+    
+    self.removeHandle = [self.ref observeEventType:FEventTypeChildRemoved
+                                         withBlock:^(FDataSnapshot *snapshot) {
+                                             [welf handleRemove:snapshot];
+                                         }];
+    
+    self.changeHandle = [self.ref observeEventType:FEventTypeChildChanged
+                                         withBlock:^(FDataSnapshot *snapshot) {
+                                             [welf handleChange:snapshot];
+                                         }];
+    self.valueHandle = [self.ref observeEventType:FEventTypeValue
+                                        withBlock:^(FDataSnapshot *snapshot) {
+                                            [welf handleValue:snapshot];
+                                        }];
+}
+
+- (void)handleValue:(FDataSnapshot *)snapshot;
+{
+    if (!self.initialValuesSet) {
+        [self willChangeValueForKey:@"initialValuesSet"];
+        _initialValuesSet = YES;
+        [self didChangeValueForKey:@"initialValuesSet"];
+        
+        for (id <FirebaseSetDelegate> delegate in self.delegates) {
+            if ([delegate respondsToSelector:@selector(firebaseSetCompletedInitialization:)]) {
+                [delegate firebaseSetCompletedInitialization:self];
+            }
+        }
+    }
+    
+    for (id <FirebaseSetDelegate> delegate in self.delegates) {
+        if ([delegate respondsToSelector:@selector(firebaseSetCompletedUpdates:)]) {
+            [delegate firebaseSetCompletedUpdates:self];
+        }
+    }
+}
+
+- (void)handleAdd:(FDataSnapshot *)snapshot;
+{
+    id preparedObject = [self prepareSnapshot:snapshot];
+    
+    if (!preparedObject) {
+        return;
+    }
+    
+    [self.mutableObjects addObject:preparedObject];
+    [self.table setObject:preparedObject forKey:snapshot.key];
+    
+    for (id <FirebaseSetDelegate> delegate in self.delegates) {
+        if ([delegate respondsToSelector:@selector(firebaseSet:added:)]) {
+            [delegate firebaseSet:self added:preparedObject];
+        }
+    }
+}
+
+- (void)handleRemove:(FDataSnapshot *)snapshot;
+{
+    id object = [self.table objectForKey:snapshot.key];
+    
+    if (!object) {
+        return;
+    }
+    
+    [self.mutableObjects removeObject:object];
+    [self.table removeObjectForKey:snapshot.key];
+    
+    for (id <FirebaseSetDelegate> delegate in self.delegates) {
+        if ([delegate respondsToSelector:@selector(firebaseSet:removed:)]) {
+            [delegate firebaseSet:self removed:object];
+        }
+    }
+}
+
+- (void)handleChange:(FDataSnapshot *)snapshot;
+{
+    id object = [self.table objectForKey:snapshot.key];
+    
+    id preparedObject;
+    
+    if (self.changeHandlerBlock) {
+        preparedObject = self.changeHandlerBlock(snapshot, object);
+    } else {
+        [self.mutableObjects removeObject:object];
+        
+        preparedObject = [self prepareSnapshot:snapshot];
+        [self.mutableObjects addObject:preparedObject];
+        [self.table setObject:preparedObject forKey:snapshot.key];
+    }
+    
+    for (id <FirebaseSetDelegate> delegate in self.delegates) {
+        if ([delegate respondsToSelector:@selector(firebaseSet:changed:)]) {
+            [delegate firebaseSet:self changed:preparedObject];
+        }
+    }
+}
+
+- (void)endAllObservers;
+{
+    [self.ref removeObserverWithHandle:self.addHandle];
+    [self.ref removeObserverWithHandle:self.removeHandle];
+    [self.ref removeObserverWithHandle:self.changeHandle];
+    [self.ref removeObserverWithHandle:self.valueHandle];
+}
+
+@end

--- a/FirebaseUI/FirebaseSetDelegate.h
+++ b/FirebaseUI/FirebaseSetDelegate.h
@@ -1,0 +1,66 @@
+//
+//  FirebaseSetDelegate.h
+//  FirebaseUI
+//
+//  Created by Zoe Van Brunt on 11/25/15.
+//  Copyright © 2015 Firebase, Inc. All rights reserved.
+//
+
+#ifndef FirebaseSetDelegate_h
+#define FirebaseSetDelegate_h
+
+#import "FirebaseSetObject.h"
+
+@class FirebaseSet;
+
+@protocol FirebaseSetDelegate<NSObject>
+
+@optional
+
+/**
+ * Delegate method which is called whenever an object is added to the set.
+ * This method corresponds to an @p [FEventTypeChildAdded] event.
+ * @param firebaseSet The @p firebaseSet which is the sender.
+ * @param obj The object being added to the set.
+ */
+- (void)firebaseSet:(FirebaseSet *)firebaseSet added:(NSObject <FirebaseSetObject> *)obj;
+
+/**
+ * Delegate method which is called whenever an object is removed from the
+ * set. This method corresponds to an @p [FEventTypeChildRemoved] event.
+ * @param firebaseSet The @p firebaseSet which is the sender.
+ * @param obj The object being removed from the set.
+ */
+- (void)firebaseSet:(FirebaseSet *)firebaseSet removed:(NSObject <FirebaseSetObject> *)obj;
+
+/**
+ * Delegate method which is called whenever an object is changed in the
+ * set. This method corresponds to an @p [FEventTypeChildChanged] event.
+ * @param firebaseSet The @p firebaseSet which is the sender.
+ * @param obj The object that has been changed within the set.
+ */
+- (void)firebaseSet:(FirebaseSet *)firebaseSet changed:(NSObject <FirebaseSetObject> *)obj;
+
+/**
+ * Delegate method which is called once after all the initial add events
+ * are complete. This method corresponds to the first @p [FEventTypeValue]
+ * event guaranteed to happen after all @p [FEventTypeChildAdded] events have
+ * occured.
+ * @param firebaseSet The @p firebaseSet which is the sender.
+ * @warning This method will fire in addition to 
+ * @p firebaseSetCompletedUpdates
+ */
+- (void)firebaseSetCompletedInitialization:(FirebaseSet *)firebaseSet;
+
+/**
+ * Delegate method which is called after all incoming updates have fired.
+ * This method corresponds to an @p [FEventTypeValue] event.
+ * @param firebaseSet The firebaseSet which is the sender.
+ * @warning The first time this method will fire will be in addition to the
+ * single @p firebaseSetCompletedInitialization call.
+ */
+- (void)firebaseSetCompletedUpdates:(FirebaseSet *)firebaseSet;
+
+@end
+
+#endif /* FirebaseSetDelegate_h */

--- a/FirebaseUI/FirebaseSetObject.h
+++ b/FirebaseUI/FirebaseSetObject.h
@@ -1,0 +1,25 @@
+//
+//  FirebaseSortedObject.h
+//  FirebaseUI
+//
+//  Created by Zoe Van Brunt on 11/26/15.
+//  Copyright © 2015 Firebase, Inc. All rights reserved.
+//
+
+#ifndef FirebaseSetObject_h
+#define FirebaseSetObject_h
+
+@protocol FirebaseSetObject <NSObject>
+
+/**
+ * A unique identifier within the scope of the @p FirebaseSet's ref. The
+ * recommended implementation would be to copy the @p FDataSnapshot's @p key 
+ * property to your custom class.
+ * @see FDataSnapshot
+ */
+- (NSString *)key;
+
+@end
+
+
+#endif /* FirebaseSetObject_h */

--- a/FirebaseUI/FirebaseSortedData.h
+++ b/FirebaseUI/FirebaseSortedData.h
@@ -1,0 +1,144 @@
+//
+//  FirebaseSortedData.h
+//  FirebaseUI
+//
+//  Created by Zoe Van Brunt on 11/25/15.
+//  Copyright © 2015 Firebase, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "FirebaseSetDelegate.h"
+#import "FirebaseSortedDataDelegate.h"
+#import "FirebaseSetObject.h"
+
+@class FirebaseSet, FQuery, Firebase;
+
+/**
+ * @p FirebaseSortedData is a wrapper object for a @p FirebaseSet that provides
+ * an optionally sorted and filtered representation that is suitable for
+ * building a dataSource for a @p UITableView or @p UICollectionView.
+ * @code
+ FirebaseSortedData * data = [[FirebaseSortedData alloc] init];
+ data.predicate = aPredicate;
+ data.sectionKeyPath = \@"a.key.path";
+ data.sectionsOrderedAscending = NO;
+ data.sortDescriptors = @[aSortDescriptor, anotherSortDescriptor];
+ data.firebaseSet = myFirebaseSet; // Set the firebaseSet property last
+ */
+@interface FirebaseSortedData : NSObject <FirebaseSetDelegate>
+
+/**
+ * The @p FirebaseSet which the @p FirebaseSortedData is built upon.
+ */
+@property (nonatomic, strong) FirebaseSet * firebaseSet;
+
+/**
+ * The delegate to which updates are surfaced.
+ * @see FirebaseSortedDataDelegate
+ */
+@property (nonatomic, weak) id <FirebaseSortedDataDelegate> delegate;
+
+/**
+ * This propery returns a sorted representation of all the sorted and 
+ * filtered objects at the moment it was called for.
+ */
+@property (nonatomic, readonly) NSArray <id <FirebaseSetObject>> * sortedObjects;
+
+/**
+ * The array of @p NSSortDescriptors by which the data is sorted. The 
+ * zeroth being the most significant descriptor.
+ * @warning Setting this property will cause a delegate call to reload if
+ * the @p firebaseSet property is not @p nil.
+ * @see FirebaseSortedDataDelegate
+ */
+@property (nonatomic, strong) NSArray <NSSortDescriptor *> * sortDescriptors;
+
+/**
+ * The NSPredicate by which the data is filtered.
+ * @warning Setting this property will cause a delegate call to reload if
+ * the @p firebaseSet property is not @p nil.
+ * @see FirebaseSortedDataDelegate
+ */
+@property (nonatomic, strong) NSPredicate * predicate;
+
+/**
+ * The key path by which data is divided into sections. Use this as you
+ * would for @p valueForKeyPath: in the @p \@"property.subproperty" format.
+ * @warning Keep in mind what kind of objects you are using. If the
+ * FirebaseSet uses a custom object class, use the appropriate keypath.
+ * Otherwise, for an @p FDataSnapshot, you may have to format your keyPath
+ * @p \@"value.yourKey" in order to access your values.
+ * @warning Setting this property will cause a delegate call to reload if
+ * the @p firebaseSet property is not @p nil.
+ * @see FDataSnapshot, FirebaseSet
+ */
+@property (nonatomic, strong) NSString * sectionKeyPath;
+
+/**
+ * Use in conjunction with @p sectionKeyPath to determine whether sections
+ * are ordered in ascending order by the @p compare: method.
+ * @warning Setting this property will cause a delegate call to reload if
+ * the @p firebaseSet property is not @p nil.
+ */
+@property (nonatomic) BOOL sectionsOrderedAscending;
+
+/**
+ * A sorted array of the values sections are determined by.
+ * @return @p nil if @p sectionKeyPath is not set.
+ */
+@property (nonatomic, readonly) NSArray <id> * sectionValues;
+
+/**
+ * The total number of objects in the @p FirebaseSortedData object.
+ */
+@property (nonatomic) NSUInteger count;
+
+/**
+ * The total number of sections in the @p FirebaseSortedData object.
+ */
+@property (nonatomic) NSUInteger numberOfSections;
+
+#pragma mark Initializer Methods
+
+/**
+ * Initializes @p FirebaseSortedData with a @p Firebase reference.
+ * @param ref The @p Firebase reference with which to create the underlying
+ * @p FirebaseSet.
+ * @see FirebaseSet, Firebase
+ */
+- (instancetype)initWithRef:(Firebase *)ref;
+
+/**
+ * Initializes @p FirebaseSortedData with a @p FirebaseSet.
+ * @param ref The underlying @p FirebaseSet.
+ * @warning This will not call @p initiateObservers on the @p firebaseSet.
+ * @see FirebaseSet
+ */
+- (instancetype)initWithFirebaseSet:(FirebaseSet *)firebaseSet;
+
+#pragma mark API Methods
+
+/**
+ * Returns the number of objects in a section.
+ * @param sectionIndex The section to retrieve the number of objects from.
+ * @returns The number of objects in the section.
+ */
+- (NSUInteger)numberOfObjectsInSection:(NSUInteger)sectionIndex;
+
+/**
+ * Returns an array of the objects in a section.
+ * @param sectionIndex The section to retrieve the objects from.
+ * @returns An array of sorted objects in the section.
+ */
+- (NSArray *)sectionAtIndex:(NSUInteger)sectionIndex;
+
+/**
+ * Returns the object in the @p FirebaseSortedData at the @p indexPath.
+ * @param indexPath The @p NSIndexPath from which to retrieve the object.
+ * @returns The object at the @p indexPath.
+ * @see NSIndexPath
+ */
+- (id)objectAtIndexPath:(NSIndexPath *)indexPath;
+
+@end

--- a/FirebaseUI/FirebaseSortedData.m
+++ b/FirebaseUI/FirebaseSortedData.m
@@ -1,0 +1,516 @@
+//
+//  FirebaseSortedData.m
+//  FirebaseUI
+//
+//  Created by Zoe Van Brunt on 11/25/15.
+//  Copyright © 2015 Firebase, Inc. All rights reserved.
+//
+
+#import "FirebaseSortedData.h"
+
+#import "FirebaseSet.h"
+
+#import <UIKit/UITableView.h>
+
+#import <Firebase/FDataSnapshot.h>
+
+static NSString * singleSectionKey = @"singleSectionKey";
+
+@interface FSDMutableSortedDictionaryOfArrays : NSObject
+
+- (instancetype)initWithSortDescriptors:(NSArray <NSSortDescriptor *> *)sortDescriptors
+                   keysOrderedAscending:(BOOL)keysOrderedAscending
+                uniqueIdentifierKeyPath:(NSString *)uniqueIdentifierKeyPath;
+- (NSArray *)orderedKeys;
+- (NSUInteger)indexOfKey:(id)key;
+- (NSUInteger)insertionIndexForKey:(id)key;
+- (NSIndexPath *)insertObject:(id)object forKey:(id)key;
+- (NSIndexPath *)removeObject:(id)object;
+- (void)removeKeyAtIndex:(NSUInteger)index;
+- (void)removeObjectAtIndexPath:(NSIndexPath *)indexPath;
+- (NSUInteger)indexOfObject:(id)object forKey:(id)key;
+- (NSIndexPath *)indexPathOfObject:(id)object;
+- (id)objectAtIndexPath:(NSIndexPath *)indexPath;
+- (NSArray *)allSortedObjects;
+- (NSArray *)arrayAtIndex:(NSUInteger)index;
+- (void)addSortedArray:(NSArray *)array forKey:(id)key;
+
+@end
+
+@interface FDataSnapshot (FirebaseSetObject) <FirebaseSetObject>
+@end
+@implementation FDataSnapshot (FirebaseSetObject)
+@end
+
+@interface FirebaseSortedData ()
+
+@property (nonatomic, strong) FSDMutableSortedDictionaryOfArrays * table;
+
+@end
+
+@implementation FirebaseSortedData
+
+#pragma mark Initializer Methods
+
+- (instancetype)initWithRef:(Firebase *)ref;
+{
+    FirebaseSet * fSet = [[FirebaseSet alloc] initWithRef:ref];
+    
+    return [self initWithFirebaseSet:fSet];
+}
+
+
+- (instancetype)initWithFirebaseSet:(FirebaseSet *)firebaseSet;
+{
+    self = [self init];
+    
+    [self setFirebaseSet:firebaseSet];
+    
+    return self;
+}
+
+- (instancetype)init;
+{
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+    
+    return self;
+}
+
+- (void)dealloc;
+{
+    [self.firebaseSet removeDelegate:self];
+}
+
+
+#pragma mark Public API Methods
+
+- (void)setFirebaseSet:(FirebaseSet *)firebaseSet;
+{
+    _firebaseSet = firebaseSet;
+    [_firebaseSet addDelegate:self];
+    
+    [self initializeSortedObjects];
+}
+
+- (void)setPredicate:(NSPredicate *)predicate;
+{
+    _predicate = predicate;
+    
+    if (self.firebaseSet) {
+        [self initializeSortedObjects];
+    }
+}
+
+- (void)setSortDescriptors:(NSArray<NSSortDescriptor *> *)sortDescriptors;
+{
+    _sortDescriptors = sortDescriptors;
+    
+    if (self.firebaseSet) {
+        [self initializeSortedObjects];
+    }
+}
+
+- (void)setSectionKeyPath:(NSString *)sectionKeyPath;
+{
+    _sectionKeyPath = sectionKeyPath;
+    
+    if (self.firebaseSet) {
+        [self initializeSortedObjects];
+    }
+}
+
+- (void)setSectionsOrderedAscending:(BOOL)sectionsOrderedAscending;
+{
+    _sectionsOrderedAscending = sectionsOrderedAscending;
+    
+    if (self.firebaseSet) {
+        [self initializeSortedObjects];
+    }
+}
+
+- (id)objectAtIndexPath:(NSIndexPath *)indexPath;
+{
+    return [self.table objectAtIndexPath:indexPath];
+}
+
+
+- (NSArray<id> *)sortedObjects;
+{
+    return [self.table allSortedObjects];
+}
+
+
+- (NSArray *)sectionAtIndex:(NSUInteger)sectionIndex;
+{
+    return [self.table arrayAtIndex:sectionIndex];
+}
+
+- (NSArray<id> *)sectionValues;
+{
+    if (self.sectionKeyPath) {
+        return [self.table orderedKeys];
+    }
+    return nil;
+}
+
+
+- (NSUInteger)count;
+{
+    return [self.table allSortedObjects].count;
+}
+
+
+- (NSUInteger)numberOfObjectsInSection:(NSUInteger)sectionIndex;
+{
+    return [self sectionAtIndex:sectionIndex].count;
+}
+
+
+- (NSUInteger)numberOfSections;
+{
+    return [self.table orderedKeys].count;
+}
+
+#pragma mark Private API Methods
+
+- (void)initializeSortedObjects;
+{
+    self.table = [[FSDMutableSortedDictionaryOfArrays alloc] initWithSortDescriptors:[self aggregateSortDescriptors]
+                                                                keysOrderedAscending:self.sectionsOrderedAscending
+                                                             uniqueIdentifierKeyPath:@"key"];
+    
+    NSSet * objects = [self.firebaseSet objects];
+    
+    if (!objects.count) {
+        return;
+    }
+    
+    NSPredicate * predicate = self.predicate;
+    
+    if (predicate) {
+        objects = [objects filteredSetUsingPredicate:predicate];
+    }
+    
+    NSArray <NSSortDescriptor *> * sortDescriptors = [self aggregateSortDescriptors];
+    
+    if (self.sectionKeyPath) {
+        NSSortDescriptor * sectionSort =
+        [NSSortDescriptor sortDescriptorWithKey:self.sectionKeyPath
+                                      ascending:self.sectionsOrderedAscending];
+        
+        sortDescriptors = [@[sectionSort] arrayByAddingObjectsFromArray:sortDescriptors];
+        
+        NSSet * sectionValues = [objects valueForKey:self.sectionKeyPath];
+        
+        for (id sectionValue in sectionValues) {
+            NSExpression * lhs = [NSExpression expressionForKeyPath:self.sectionKeyPath];
+            NSExpression * rhs = [NSExpression expressionForConstantValue:sectionValue];
+            NSPredicate * sectionPredicate =
+            [NSComparisonPredicate predicateWithLeftExpression:lhs
+                                               rightExpression:rhs
+                                                      modifier:NSDirectPredicateModifier
+                                                          type:NSEqualToPredicateOperatorType
+                                                       options:0];
+            NSSet * filteredSet = [objects filteredSetUsingPredicate:sectionPredicate];
+            NSArray * sortedSection = [filteredSet sortedArrayUsingDescriptors:sortDescriptors];
+            
+            [self.table addSortedArray:sortedSection forKey:sectionValue];
+        }
+    } else {
+        NSArray * sortedObjects = [objects sortedArrayUsingDescriptors:sortDescriptors];
+        
+        [self.table addSortedArray:sortedObjects forKey:singleSectionKey];
+    }
+    
+    [self.delegate reload];
+}
+
+- (NSArray <NSSortDescriptor *> *)aggregateSortDescriptors;
+{
+    NSArray * sortDescriptors = [NSArray arrayWithArray:self.sortDescriptors];
+    
+    NSSortDescriptor * keyDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"key" ascending:YES];
+    sortDescriptors = [sortDescriptors arrayByAddingObject:keyDescriptor];
+    
+    return sortDescriptors;
+}
+
+#pragma mark FirebaseSetDelegate
+
+- (void)firebaseSet:(FirebaseSet *)firebaseSet added:(NSObject <FirebaseSetObject> *)obj;
+{
+    if (self.predicate && ![self.predicate evaluateWithObject:obj]) {
+        return;
+    }
+    
+    id sectionValue =
+    self.sectionKeyPath? [obj valueForKeyPath:self.sectionKeyPath] : singleSectionKey;
+    
+    NSIndexPath * path = [self.table insertObject:obj forKey:sectionValue];
+    
+    if ([self numberOfObjectsInSection:path.section] == 1) {
+        [self.delegate sectionAddedAtSectionIndex:path.section];
+    } else {
+        [self.delegate childAdded:obj atIndexPath:path];
+    }
+}
+
+- (void)firebaseSet:(FirebaseSet *)firebaseSet removed:(NSObject <FirebaseSetObject> *)obj;
+{
+    NSIndexPath * path = [self.table removeObject:obj];
+    
+    if (!path) {
+        return;
+    }
+    
+    if ([self numberOfObjectsInSection:path.section] == 0) {
+        [self.table removeKeyAtIndex:path.section];
+        [self.delegate sectionRemovedAtSectionIndex:path.section];
+    } else {
+        [self.delegate childRemoved:obj atIndexPath:path];
+    }
+}
+
+- (void)firebaseSet:(FirebaseSet *)firebaseSet changed:(NSObject<FirebaseSetObject> *)changedObject;
+{
+    NSIndexPath * startingPath = [self.table indexPathOfObject:changedObject];
+    
+    if (self.predicate) {
+        BOOL objectPassesPredicate = [self.predicate evaluateWithObject:changedObject];
+        
+        if (!startingPath && !objectPassesPredicate) {
+            return;
+        }
+        if (!objectPassesPredicate) {
+            [self firebaseSet:firebaseSet removed:changedObject];
+            return;
+        }
+        if (!startingPath) {
+            [self firebaseSet:firebaseSet added:changedObject];
+            return;
+        }
+    }
+    
+    
+    [self.table removeObjectAtIndexPath:startingPath];
+    
+    BOOL removeSection = [self numberOfObjectsInSection:startingPath.section] == 0;
+    if (removeSection) {
+        [self.table removeKeyAtIndex:startingPath.section];
+    }
+    
+    NSIndexPath * endingPath;
+    if (self.sectionKeyPath) {
+        id endingSectionValue = [changedObject valueForKeyPath:self.sectionKeyPath];
+        endingPath = [self.table insertObject:changedObject forKey:endingSectionValue];
+    } else {
+        endingPath = [self.table insertObject:changedObject forKey:singleSectionKey];
+    }
+    
+    
+    if ([startingPath compare:endingPath] == NSOrderedSame) {
+        [self.delegate childChanged:changedObject atIndexPath:endingPath];
+        return;
+    }
+    
+    [self.delegate beginUpdates];
+    if (removeSection) {
+        [self.delegate sectionRemovedAtSectionIndex:startingPath.section];
+    } else {
+        [self.delegate childRemoved:changedObject atIndexPath:startingPath];
+    }
+    
+    if ([self numberOfObjectsInSection:endingPath.section] == 1) {
+        [self.delegate sectionAddedAtSectionIndex:endingPath.section];
+    } else {
+        [self.delegate childAdded:changedObject atIndexPath:endingPath];
+    }
+    [self.delegate endUpdates];
+}
+
+@end
+
+@implementation FSDMutableSortedDictionaryOfArrays {
+    NSMutableDictionary <id, NSMutableArray *> * _dictionary;
+    NSComparisonResult (^_comparator)(id  _Nonnull obj1, id  _Nonnull obj2);
+    NSComparisonResult (^_arrayComparator)(id  _Nonnull obj1, id  _Nonnull obj2);
+    NSString * _uniqueIdentifierKeyPath;
+}
+
+- (instancetype)initWithSortDescriptors:(NSArray<NSSortDescriptor *> *)sortDescriptors
+                   keysOrderedAscending:(BOOL)keysOrderedAscending
+                uniqueIdentifierKeyPath:(NSString *)uniqueIdentifierKeyPath;
+{
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+    
+    _dictionary = [NSMutableDictionary dictionary];
+    
+    _comparator = ^NSComparisonResult(id  _Nonnull obj1, id  _Nonnull obj2) {
+        if (keysOrderedAscending)
+        { return [obj1 compare:obj2]; }
+        else
+        { return [obj2 compare:obj1]; }
+    };
+    
+    _arrayComparator = ^NSComparisonResult(id  _Nonnull obj1, id  _Nonnull obj2) {
+        NSArray * sort = sortDescriptors;
+        
+        NSComparisonResult result = NSOrderedSame;
+        for (NSSortDescriptor * sortDescriptor in sort) {
+            result = [sortDescriptor compareObject:obj1 toObject:obj2];
+            if (result != NSOrderedSame) { break; }
+        }
+        return result;
+    };
+    
+    _uniqueIdentifierKeyPath = uniqueIdentifierKeyPath;
+    
+    return self;
+}
+
+- (NSArray *)orderedKeys;
+{
+    return [_dictionary.allKeys sortedArrayWithOptions:NSSortConcurrent
+                                       usingComparator:_comparator];
+}
+
+- (NSUInteger)indexOfKey:(id)key;
+{
+    return [[self orderedKeys] indexOfObject:key];
+}
+
+- (NSUInteger)insertionIndexForKey:(id)key;
+{
+    NSArray * orderedKeys = [self orderedKeys];
+    return [orderedKeys indexOfObject:key
+                        inSortedRange:(NSRange){0, orderedKeys.count}
+                              options:NSBinarySearchingInsertionIndex
+                      usingComparator:_comparator];
+}
+
+- (NSIndexPath *)insertObject:(id)object forKey:(id)key;
+{
+    NSUInteger row;
+    NSUInteger section;
+    
+    if ([_dictionary.allKeys containsObject:key]) {
+        NSMutableArray * array = _dictionary[key];
+        NSUInteger index = [array indexOfObject:object
+                                  inSortedRange:(NSRange){0, array.count}
+                                        options:NSBinarySearchingInsertionIndex
+                                usingComparator:_arrayComparator];
+        [array insertObject:object atIndex:index];
+        row = index;
+    } else {
+        NSMutableArray * array = [NSMutableArray arrayWithObject:object];
+        _dictionary[key] = array;
+        row = 0;
+    }
+    
+    section = [self indexOfKey:key];
+    
+    return [NSIndexPath indexPathForRow:row inSection:section];
+}
+
+- (NSIndexPath *)removeObject:(id)object;
+{
+    NSIndexPath * indexPath = [self indexPathOfObject:object];
+    
+    if (!indexPath) {
+        return nil;
+    }
+    
+    [self removeObjectAtIndexPath:indexPath];
+    
+    return indexPath;
+}
+
+- (void)removeObjectAtIndexPath:(NSIndexPath *)indexPath;
+{
+    id key = [self orderedKeys][indexPath.section];
+    
+    NSMutableArray * array = _dictionary[key];
+    
+    [array removeObjectAtIndex:indexPath.row];
+}
+
+- (void)removeKeyAtIndex:(NSUInteger)index;
+{
+    id key = self.orderedKeys[index];
+    
+    [_dictionary removeObjectForKey:key];
+}
+
+- (NSUInteger)indexOfObject:(id)object forKey:(id)key;
+{
+    NSMutableArray * array = _dictionary[key];
+    
+    return [self indexOfObject:object inArray:array];
+}
+
+- (NSUInteger)indexOfObject:(id)object inArray:(NSArray *)array {
+    
+    id uid = [object valueForKeyPath:_uniqueIdentifierKeyPath];
+    
+    return [array indexOfObjectWithOptions:NSEnumerationConcurrent passingTest:^BOOL(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+        return [[obj valueForKeyPath:_uniqueIdentifierKeyPath] compare:uid] == NSOrderedSame;
+    }];
+}
+
+- (NSIndexPath *)indexPathOfObject:(id)object;
+{
+    __block id key;
+    __block NSUInteger row = NSNotFound;
+    [_dictionary enumerateKeysAndObjectsWithOptions:NSEnumerationConcurrent usingBlock:^(id  _Nonnull blockKey, NSMutableArray * _Nonnull array, BOOL * _Nonnull stop) {
+        NSUInteger index = [self indexOfObject:object inArray:array];
+        if (index != NSNotFound) {
+            key = blockKey;
+            row = index;
+            *stop = YES;
+        }
+    }];
+    
+    if (row == NSNotFound) {
+        return nil;
+    }
+    
+    NSUInteger section = [self indexOfKey:key];
+    
+    return [NSIndexPath indexPathForRow:row inSection:section];
+}
+
+- (id)objectAtIndexPath:(NSIndexPath *)indexPath;
+{
+    id key = [self orderedKeys][indexPath.section];
+    
+    return _dictionary[key][indexPath.row];
+}
+
+- (NSArray *)allSortedObjects;
+{
+    NSMutableArray * array = [NSMutableArray array];
+    for (id key in [self orderedKeys]) {
+        [array addObjectsFromArray:_dictionary[key]];
+    }
+    return array;
+}
+
+- (NSArray *)arrayAtIndex:(NSUInteger)index;
+{
+    id key = [self orderedKeys][index];
+    
+    return _dictionary[key];
+}
+
+- (void)addSortedArray:(NSArray *)array forKey:(id)key;
+{
+    _dictionary[key] = [NSMutableArray arrayWithArray:array];
+}
+
+@end

--- a/FirebaseUI/FirebaseSortedDataDelegate.h
+++ b/FirebaseUI/FirebaseSortedDataDelegate.h
@@ -1,0 +1,91 @@
+//
+//  FirebaseSortedDataDelegate.h
+//  ZoeLogDA
+//
+//  Created by Zoe Van Brunt on 12/1/15.
+//  Copyright © 2015 Zoe Van Brunt. All rights reserved.
+//
+
+#ifndef FirebaseSortedDataDelegate_h
+#define FirebaseSortedDataDelegate_h
+
+@protocol FirebaseSortedDataDelegate <NSObject>
+
+/**
+ * Delegate method which is called whenever an object is added to the
+ * FirebaseSortedData. This may correspond to an [FEventTypeChildAdded]
+ * event. In the case of a FirebaseSortedData object with a predicate,
+ * an [FEventTypeChildChanged] event may cause an object to conform to
+ * the predicate when it previously didn't.
+ * @param object The object added to the FirebaseSortedData
+ * @param indexPath The indexPath the child was added at
+ */
+- (void)childAdded:(id)obj atIndexPath:(NSIndexPath *)indexPath;
+
+/**
+ * Delegate method which is called when an object is changed in the
+ * FirebaseSortedData. This corresponds to an [FEventTypeChildChanged]
+ * event. In the case of FirebaseSortedData with a predicate, this
+ * method is only called if the [FEventTypeChildChanged] event does not
+ * result in the object being removed or added due to the predicate's
+ * evaluation.
+ * @param object The object that changed in the FirebaseSortedData
+ * @param indexPath The indexPath the child was changed at
+ */
+- (void)childChanged:(id)obj atIndexPath:(NSIndexPath *)indexPath;
+
+/**
+ * Delegate method which is called whenever an object is removed from the
+ * FirebaseSortedData. This may correspond to an [FEventTypeChildRemoved]
+ * event. In the case of a FirebaseSortedData object with a predicate,
+ * an [FEventTypeChildChanged] event may cause an object to no longer
+ * conform to the predicate when it previously did.
+ * @param object The object removed from the FirebaseSortedData
+ * @param indexPath The indexPath the child was removed at
+ */
+- (void)childRemoved:(id)obj atIndexPath:(NSIndexPath *)indexPath;
+
+/**
+ * Delegate method which is called whenever a new section is created by
+ * FirebaseSortedData. This method is called even if sectionKeyPath is 
+ * not set on FirebaseSortedData. This may correspond to an
+ * [FEventTypeChildChanged] or [FEventTypeChildAdded] event.
+ * @param section The index of the section to be added.
+ */
+- (void)sectionAddedAtSectionIndex:(NSUInteger)section;
+
+/**
+ * Delegate method which is called whenever a section is removed by
+ * FirebaseSortedData. This method is called even if sectionKeyPath is
+ * not set on FirebaseSortedData. This may correspond to an
+ * [FEventTypeChildChanged] or [FEventTypeChildRemoved] event.
+ * @param section The index of the section to be removed.
+ */
+- (void)sectionRemovedAtSectionIndex:(NSUInteger)section;
+
+/**
+ * Delegate method which is called to alert the delegate that multiple
+ * complex changes are about to occur simultaneously. This would call
+ * beginUpdates on a tableView, for example.
+ */
+- (void)beginUpdates;
+
+/**
+ * Delegate method which is called to alert the delegate that multiple
+ * complex changes have occured simultaneously. This would call endUpdates 
+ * on a tableView, for example.
+ */
+- (void)endUpdates;
+
+/**
+ * Delegate method which is called to induce the delegate to reload data
+ * completely. This would call reloadData on a tableView, for example.
+ * This method is called when a predicate or sortDescriptor is changed on
+ * the FirebaseSortedData.
+ */
+- (void)reload;
+
+@end
+
+
+#endif /* FirebaseSortedDataDelegate_h */

--- a/FirebaseUI/FirebaseSortedDataSource.h
+++ b/FirebaseUI/FirebaseSortedDataSource.h
@@ -1,0 +1,36 @@
+//
+//  FirebaseSortedDataSource.h
+//  FirebaseUI
+//
+//  Created by Zoe Van Brunt on 11/26/15.
+//  Copyright © 2015 Firebase, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "FirebaseSet.h"
+#import "FirebaseSortedData.h"
+
+@interface FirebaseSortedDataSource : NSObject
+
+@property (nonatomic, strong) FirebaseSet * firebaseSet;
+@property (nonatomic, strong) FirebaseSortedData * data;
+
+@property (nonatomic, strong) NSString * (^sectionTitleBlock)(id sectionValue);
+@property (nonatomic, strong, setter = populateCellWithBlock:) void (^populateCellBlock)(id cell, NSObject * object);
+
+@property (nonatomic, strong) NSString * nibName;
+@property (nonatomic, strong) Class cellClass;
+@property (nonatomic, strong) NSString * cellReuseIdentifier;
+@property (nonatomic) NSString * prototypeCellReuseIdentifier;
+@property (nonatomic) BOOL hasPrototypeCell;
+
+- (id)objectAtIndexPath:(NSIndexPath *)indexPath;
+
+- (NSUInteger)count;
+
+- (NSString *)sectionTitleForSection:(NSUInteger)section;
+
+- (void)populateCellWithBlock:(void (^)(id cell, NSObject * object))block;
+
+@end

--- a/FirebaseUI/FirebaseSortedDataSource.m
+++ b/FirebaseUI/FirebaseSortedDataSource.m
@@ -1,0 +1,88 @@
+//
+//  FirebaseSortedDataSource.m
+//  FirebaseUI
+//
+//  Created by Zoe Van Brunt on 11/26/15.
+//  Copyright © 2015 Firebase, Inc. All rights reserved.
+//
+
+#import "FirebaseSortedDataSource.h"
+
+#import "FirebaseSortedData.h"
+#import "FirebaseSet.h"
+
+@implementation FirebaseSortedDataSource
+
+- (instancetype)init
+{
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+    
+    FirebaseSortedData * data = [[FirebaseSortedData alloc] init];
+    [self setData:data];
+    
+    return self;
+}
+
+- (void)setData:(FirebaseSortedData *)data;
+{
+    _data = data;
+    data.delegate = (id <FirebaseSortedDataDelegate>)self;
+}
+
+- (FirebaseSet *)firebaseSet;
+{
+    return self.data.firebaseSet;
+}
+
+- (void)setFirebaseSet:(FirebaseSet *)set;
+{
+    self.data.firebaseSet = set;
+}
+
+- (NSString *)sectionTitleForSection:(NSUInteger)section;
+{
+    if (!self.data.sectionKeyPath || !self.data.sectionValues.count) {
+        return nil;
+    }
+    id sectionValue = [self.data.sectionValues objectAtIndex:section];
+    
+    NSString * title;
+    
+    if (self.sectionTitleBlock) {
+        title = self.sectionTitleBlock(sectionValue);
+    } else {
+        title = [NSString stringWithFormat:@"%@", sectionValue];
+    }
+    return title;
+}
+
+#pragma mark Public API Accessors
+
+- (NSString *)prototypeCellReuseIdentifier;
+{
+    if (self.hasPrototypeCell) {
+        return self.cellReuseIdentifier;
+    }
+    return nil;
+}
+
+- (void)setPrototypeCellReuseIdentifier:(NSString *)prototypeCellReuseIdentifier;
+{
+    self.hasPrototypeCell = YES;
+    self.cellReuseIdentifier = prototypeCellReuseIdentifier;
+}
+
+- (id)objectAtIndexPath:(NSIndexPath *)indexPath;
+{
+    return [self.data objectAtIndexPath:indexPath];
+}
+
+- (NSUInteger)count;
+{
+    return self.data.count;
+}
+
+@end

--- a/FirebaseUI/FirebaseSortedTableViewDataSource.h
+++ b/FirebaseUI/FirebaseSortedTableViewDataSource.h
@@ -1,0 +1,31 @@
+//
+//  FirebaseSortedTableViewDataSource.h
+//  FirebaseUI
+//
+//  Created by Zoe Van Brunt on 11/26/15.
+//  Copyright © 2015 Firebase, Inc. All rights reserved.
+//
+
+#import "FirebaseSortedDataSource.h"
+#import "FirebaseSortedDataDelegate.h"
+#import <UIKit/UIKit.h>
+
+@interface FirebaseSortedTableViewDataSource : FirebaseSortedDataSource <UITableViewDataSource, FirebaseSortedDataDelegate>
+
+/**
+ * The UITableView instance that operations (inserts, removals, moves, etc.) are
+ * performed against.
+ */
+@property (strong, nonatomic) UITableView *tableView;
+
+/**
+ * Override to customize UITableView animations.
+ */
+@property (nonatomic) UITableViewRowAnimation childInsertAnimation;
+@property (nonatomic) UITableViewRowAnimation childReloadAnimation;
+@property (nonatomic) UITableViewRowAnimation childDeleteAnimation;
+@property (nonatomic) UITableViewRowAnimation sectionInsertAnimation;
+@property (nonatomic) UITableViewRowAnimation sectionReloadAnimation;
+@property (nonatomic) UITableViewRowAnimation sectionDeleteAnimation;
+
+@end

--- a/FirebaseUI/FirebaseSortedTableViewDataSource.m
+++ b/FirebaseUI/FirebaseSortedTableViewDataSource.m
@@ -1,0 +1,130 @@
+//
+//  FirebaseSortedTableViewDataSource.m
+//  FirebaseUI
+//
+//  Created by Zoe Van Brunt on 11/26/15.
+//  Copyright © 2015 Firebase, Inc. All rights reserved.
+//
+
+#import "FirebaseSortedTableViewDataSource.h"
+#import "FirebaseSortedData.h"
+
+@implementation FirebaseSortedTableViewDataSource
+
+- (instancetype)init;
+{
+    self = [super init];
+    
+    if (!self) {
+        return nil;
+    }
+    
+    self.childInsertAnimation = UITableViewRowAnimationAutomatic;
+    self.childReloadAnimation = UITableViewRowAnimationAutomatic;
+    self.childDeleteAnimation = UITableViewRowAnimationAutomatic;
+    self.sectionInsertAnimation = UITableViewRowAnimationAutomatic;
+    self.sectionReloadAnimation = UITableViewRowAnimationAutomatic;
+    self.sectionDeleteAnimation = UITableViewRowAnimationAutomatic;
+    
+    return self;
+}
+
+#pragma mark -
+#pragma mark FirebaseCollectionDelegate methods
+
+- (void)childAdded:(id)obj atIndexPath:(NSIndexPath *)indexPath;
+{
+    [self.tableView insertRowsAtIndexPaths:@[indexPath]
+                          withRowAnimation:self.childInsertAnimation];
+}
+
+- (void)childChanged:(id)obj atIndexPath:(NSIndexPath *)indexPath;
+{
+    [self.tableView reloadRowsAtIndexPaths:@[indexPath]
+                          withRowAnimation:self.childReloadAnimation];
+}
+
+- (void)childRemoved:(id)obj atIndexPath:(NSIndexPath *)indexPath;
+{
+    [self.tableView deleteRowsAtIndexPaths:@[indexPath]
+                          withRowAnimation:self.childDeleteAnimation];
+}
+
+- (void)sectionAddedAtSectionIndex:(NSUInteger)section;
+{
+    [self.tableView insertSections:[NSIndexSet indexSetWithIndex:section]
+                  withRowAnimation:self.sectionInsertAnimation];
+}
+
+- (void)sectionRemovedAtSectionIndex:(NSUInteger)section;
+{
+    [self.tableView deleteSections:[NSIndexSet indexSetWithIndex:section]
+                  withRowAnimation:self.sectionDeleteAnimation];
+}
+
+- (void)reload;
+{
+    [self.tableView reloadData];
+}
+
+-(void)beginUpdates;
+{
+    [self.tableView beginUpdates];
+}
+
+-(void)endUpdates;
+{
+    [self.tableView endUpdates];
+}
+
+#pragma mark -
+#pragma mark UITableViewDataSource methods
+
+- (UITableViewCell *)tableView:(UITableView *)tableView
+         cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    id cell =
+    [tableView dequeueReusableCellWithIdentifier:self.cellReuseIdentifier
+                                    forIndexPath:indexPath];
+    
+    id obj = [self.data objectAtIndexPath:indexPath];
+    
+    if (self.populateCellBlock) {
+        self.populateCellBlock(cell, obj);
+    }
+    
+    return cell;
+}
+
+-(NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
+    return [self sectionTitleForSection:section];
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    NSUInteger rows = [self.data numberOfObjectsInSection:section];
+    return rows;
+}
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+    NSUInteger sections = [self.data numberOfSections];
+    return sections;
+}
+
+#pragma mark -
+#pragma mark Public API methods
+
+- (void)setCellReuseIdentifier:(NSString *)cellReuseIdentifier {
+    [super setCellReuseIdentifier:cellReuseIdentifier];
+    
+    if (self.hasPrototypeCell) {
+        return;
+    }
+    
+    if (self.nibName) {
+        [self.tableView registerNib:[UINib nibWithNibName:self.nibName bundle:nil]
+             forCellReuseIdentifier:cellReuseIdentifier];
+    } else if (self.cellClass) {
+        [self.tableView registerClass:self.cellClass forCellReuseIdentifier:cellReuseIdentifier];
+    }
+}
+
+@end


### PR DESCRIPTION
# FirebaseSet

`FirebaseSet` combines my previous work on `FirebaseArray` into a new set-style object, while leaving `FirebaseArray`'s functionality intact.

`FirebaseSet` is used as a property, as you would with any other collection.

```
@property (nonatomic, strong) FirebaseSet * firebaseSet;
```

The difference comes when you initialize it.

```
Firebase * ref = [[Firebase alloc] initWithUrl:@"https://firebaseui.firebaseio.com/chat"];

self.firebaseSet = [[FirebaseSet alloc] initWithRef:ref];

[self.firebaseSet initiateObservers];
```

Calling `initiateObservers` begins syncing with the server data. Without calling this method, the `FirebaseSet` remains empty.

If you add a delegate to the `FirebaseSet`, it will receive updates through the `FirebaseSetDelegate` methods. For example:

```
- (void)firebaseSetCompletedUpdates:(FirebaseSet *)firebaseSet {
    //This method corresponds to [FEventTypeValue]
    NSPredicate * predicate = [NSPredicate predicateWithFormat:@"hidden == %@", @NO];

    NSSet * filteredObjects = [firebaseSet.objects filteredSetUsingPredicate:predicate];

    NSUInteger count = [filteredObjects count];

    [[NSOperationQueue mainQueue] addOperationWithBlock:^{
        //Update the UI
    }
}
```

`FirebaseSet` can store objects as a custom class using the `classConversionBlock` and `changeHandlerBlock` properties. Your custom class must conform to the `FirebaseSetObject` protocol.

Included are `FirebaseSortedData`, `FirebaseSortedDataSource`, and `FirebaseSortedTableViewDataSource`. Using a `FirebaseSet` as the primary data source, you can create sectioned, sorted table views.

```
- (void)viewDidLoad {
    [super viewDidLoad];
    self.dataSource = [FirebaseSortedTableViewDataSource new];
    [self.tableView setDataSource:self.dataSource];
    [self.dataSource setTableView:self.tableView];

    [self.dataSource.data setPredicate:[NSPredicate predicateWithFormat:@"%K == %@", @"name", self.nameType]];

    [self.dataSource setNibName:@"MessageTableViewCell"];
    [self.dataSource setCellReuseIdentifier:@"MessageTableViewCell"];

    [self.dataSource populateCellWithBlock:^(id aCell, NSObject * object) {
         MessageTableViewCell * cell = (MessageTableViewCell *)aCell;
         Message * message = (Message *)object;

         [cell setupWithMessage:message];
     }];

    //self.firebaseSet was passed in on prepareForSegue, and was already initialized
    [self.dataSource setFirebaseSet:self.firebaseSet];
}
```

In the above example, because the `FirebaseSet` was already initialized and passed into the view controller, all the data is already loaded and can be presented synchronously, without delay or UI refreshing.

The documentation on the header files is mostly complete. Have fun!
