### PR TITLE
Fixed unnecessary "cell added animation" with FirebaseTableViewDataSource.

### DIFF
--- a/FirebaseUI/Core/API/FirebaseArrayDelegate.h
+++ b/FirebaseUI/Core/API/FirebaseArrayDelegate.h
@@ -40,6 +40,11 @@
 @optional
 
 /**
+ * Delegate method which is called whenever array initialized with query.
+ */
+- (void)childrenInitialized;
+
+/**
  * Delegate method which is called whenever an object is added to a
  * FirebaseArray. On a
  * FirebaseArray synchronized to a Firebase reference, this corresponds to an

--- a/FirebaseUI/Core/Implementation/FirebaseTableViewDataSource.m
+++ b/FirebaseUI/Core/Implementation/FirebaseTableViewDataSource.m
@@ -251,6 +251,10 @@
 #pragma mark -
 #pragma mark FirebaseCollectionDelegate methods
 
+-(void)childrenInitialized{
+    [self.tableView reloadData];
+}
+
 - (void)childAdded:(id)obj atIndex:(NSUInteger)index {
   [self.tableView beginUpdates];
   [self.tableView insertRowsAtIndexPaths:@[ [NSIndexPath indexPathForRow:index inSection:0] ]


### PR DESCRIPTION
https://github.com/firebase/FirebaseUI-iOS/blob/master/FirebaseUI/Core/Implementation/FirebaseTableViewDataSource.m#L254

If there are 1000 data, FirebaseTableViewDataSource calls beginUpdates, insertRowsAtIndexPaths and endUpdates 1000 times on initialize. That is a waste.

So I enhanced FirebaseArray initializing with observeSingleEventOfType.

Sorry for my poor English.
Thanks!
