### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,7 +647,7 @@ $ ./setup.sh
 
 Note that `setup.sh` pulls in a number of provider frameworks (Facebook, Google), which need to be pulled in for local development. The debug build and framework release have the flag `LOCAL_BUILD=1` which uses the local frameworks installed via `setup.sh`, while the CocoaPods release doesn't have this flag set, so the appropriate Pod `#import` statements are used.
 
-FirebaseUI makes use of XCode 7 features such as lightweight generics and `__kindof` annotations, but it should be backwards compatible to XCode 6 thanks to [XCodeMacros.h](https://github.com/firebase/FirebaseUI-iOS/blob/master/FirebaseUI/XCodeMacros.h).
+FirebaseUI makes use of Xcode 7 features such as lightweight generics and `__kindof` annotations, but it should be backwards compatible to Xcode 6 thanks to [XcodeMacros.h](https://github.com/firebase/FirebaseUI-iOS/blob/master/FirebaseUI/XcodeMacros.h).
 
 ## Deployment
 


### PR DESCRIPTION

This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
