### PR TITLE
Fixed nib and bundle references on FirebaseLoginViewController

### DIFF
--- a/FirebaseUI/Auth/Implementation/FirebaseLoginViewController.m
+++ b/FirebaseUI/Auth/Implementation/FirebaseLoginViewController.m
@@ -39,7 +39,7 @@
 
 - (instancetype)initWithRef:(Firebase *)ref;
 {
-  self = [super init];
+  self = [super initWithNibName:@"FirebaseLoginViewController" bundle:[NSBundle bundleForClass:[self class]]];
   if (self) {
     self.ref = ref;
     self.dismissCallback = ^(FAuthData *user, NSError *error) {
@@ -60,7 +60,7 @@
   }
 
   // Add cancel button
-  UIImage *image = [[UIImage imageNamed:@"ic_clear_18pt"]
+  UIImage *image = [[UIImage imageNamed:@"ic_clear_18pt" inBundle:[NSBundle bundleForClass:[self class]] compatibleWithTraitCollection:nil]
       imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
   [self.cancelButton setImage:image forState:UIControlStateNormal];
   self.cancelButton.imageView.tintColor =


### PR DESCRIPTION
Ensures that the FirebaseLoginViewController nib file is loaded in the initWithRef method, and points to the Framework's bundle.

Note that I'm testing this on Cocoapods and use_frameworks! in a Swift project. While it should always point to the correct bundle regardless of which one it is (main, external, etc) it would be prudent to test all scenarios.

See issue #51.