### PR TITLE
fix the optional error with the optional binding

### DIFF
--- a/samples/swift/uidemo/AppDelegate.swift
+++ b/samples/swift/uidemo/AppDelegate.swift
@@ -35,9 +35,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   }
   
   func application(app: UIApplication, openURL url: NSURL, options: [String : AnyObject]) -> Bool {
-    let sourceApplication = options[UIApplicationOpenURLOptionsSourceApplicationKey] as! String?
-    if FIRAuthUI.authUI()?.handleOpenURL(url, sourceApplication: sourceApplication) ?? false {
-      return true
+    if let sourceApplication = options[UIApplicationOpenURLOptionsSourceApplicationKey] as! String? {
+      if FIRAuthUI.authUI()?.handleOpenURL(url, sourceApplication: sourceApplication) ?? false {
+        return true
+      }
     }
     // other URL handling goes here.
     return false

--- a/samples/swift/uidemo/AppDelegate.swift
+++ b/samples/swift/uidemo/AppDelegate.swift
@@ -35,10 +35,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   }
   
   func application(app: UIApplication, openURL url: NSURL, options: [String : AnyObject]) -> Bool {
-    if let sourceApplication = options[UIApplicationOpenURLOptionsSourceApplicationKey] as! String? {
-      if FIRAuthUI.authUI()?.handleOpenURL(url, sourceApplication: sourceApplication) ?? false {
-        return true
-      }
+    let sourceApplication = options[UIApplicationOpenURLOptionsSourceApplicationKey] as! String?
+    if FIRAuthUI.authUI()?.handleOpenURL(url, sourceApplication: sourceApplication ?? "") ?? false {
+      return true
     }
     // other URL handling goes here.
     return false


### PR DESCRIPTION
optional `sourceApplication` has to use with the optional binding to prevent the optional syntax error. 

With the optional binding, `sourceApplication` which is the handleOpenURL method argument is always has a value.

Is there another solution?
