### PR TITLE
Dynamic Frameworks are only supported on >= iOS 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ pod 'FirebaseUI/Google', '~> 0.4'
 If you're including FirebaseUI in a Swift project, make sure you also have:
 
 ```
-platform :ios, '7.0'
+platform :ios, '8.0'
 use_frameworks!
 ```
 


### PR DESCRIPTION
Dynamic frameworks were introduced with iOS 8, and I believe cocoapods `use_frameworks!` will also only work on iOS 8 or greater.