### PR TITLE
continue to build static targets for now

### DIFF
--- a/FirebaseAuthUI/FIRAuthPickerViewController.xib
+++ b/FirebaseAuthUI/FIRAuthPickerViewController.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>

--- a/FirebaseAuthUI/FirebaseAuthUI.h
+++ b/FirebaseAuthUI/FirebaseAuthUI.h
@@ -22,9 +22,9 @@ FOUNDATION_EXPORT double FirebaseAuthUIVersionNumber;
 //! Project version string for FirebaseAuthUI.
 FOUNDATION_EXPORT const unsigned char FirebaseAuthUIVersionString[];
 
-#import <FIRAuthPickerViewController.h>
-#import <FIRAuthProviderUI.h>
-#import <FIRAuthUI.h>
-#import <FIRAuthUIBaseViewController.h>
-#import <FIRAuthUIErrorUtils.h>
+#import <FirebaseAuthUI/FIRAuthPickerViewController.h>
+#import <FirebaseAuthUI/FIRAuthProviderUI.h>
+#import <FirebaseAuthUI/FIRAuthUI.h>
+#import <FirebaseAuthUI/FIRAuthUIBaseViewController.h>
+#import <FirebaseAuthUI/FIRAuthUIErrorUtils.h>
 

--- a/FirebaseFacebookAuthUI/FIRFacebookAuthUI.h
+++ b/FirebaseFacebookAuthUI/FIRFacebookAuthUI.h
@@ -14,7 +14,7 @@
 //  limitations under the License.
 //
 
-#import <FIRAuthUI.h>
+#import <FirebaseAuthUI/FIRAuthUI.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FirebaseFacebookAuthUI/FIRFacebookAuthUI.m
+++ b/FirebaseFacebookAuthUI/FIRFacebookAuthUI.m
@@ -20,7 +20,7 @@
 #import <FirebaseAuth/FIRUserInfo.h>
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #import <FBSDKLoginKit/FBSDKLoginKit.h>
-#import <FIRAuthUIErrorUtils.h>
+#import <FirebaseAuthUI/FIRAuthUIErrorUtils.h>
 
 /** @var kBundleFileName
     @brief The name of the bundle containing Facebook auth provider assets/resources.

--- a/FirebaseGoogleAuthUI/FIRGoogleAuthUI.h
+++ b/FirebaseGoogleAuthUI/FIRGoogleAuthUI.h
@@ -14,7 +14,7 @@
 //  limitations under the License.
 //
 
-#import <FIRAuthUI.h>
+#import <FirebaseAuthUI/FIRAuthUI.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FirebaseGoogleAuthUI/FIRGoogleAuthUI.m
+++ b/FirebaseGoogleAuthUI/FIRGoogleAuthUI.m
@@ -19,7 +19,7 @@
 #import <GoogleSignIn/GoogleSignIn.h>
 #import <FirebaseAuth/FIRGoogleAuthProvider.h>
 #import <FirebaseAuth/FIRUserInfo.h>
-#import <FIRAuthUIErrorUtils.h>
+#import <FirebaseAuthUI/FIRAuthUIErrorUtils.h>
 
 /** @var kGoogleGamesScope
     @brief The OAuth scope string for the "Games" scope.

--- a/FirebaseUI.podspec
+++ b/FirebaseUI.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.author       = 'Firebase'
   s.source       = { :http => 'https://github.com/firebase/FirebaseUI-iOS/releases/download/0.5.4/FirebaseUIFrameworks.zip' }
   s.platform = :ios
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '7.0'
   s.ios.framework = 'UIKit'
   s.requires_arc = true
   s.default_subspecs = 'All'

--- a/FirebaseUI.podspec
+++ b/FirebaseUI.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseUI'
-  s.version      = '0.5.3'
+  s.version      = '0.5.4'
   s.summary      = 'UI binding libraries for Firebase.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'FirebaseUIFrameworks/LICENSE' }
   s.author       = 'Firebase'
-  s.source       = { :http => 'https://github.com/firebase/FirebaseUI-iOS/releases/download/0.5.3/FirebaseUIFrameworks.zip' }
+  s.source       = { :http => 'https://github.com/firebase/FirebaseUI-iOS/releases/download/0.5.4/FirebaseUIFrameworks.zip' }
   s.platform = :ios
   s.ios.deployment_target = '8.0'
   s.ios.framework = 'UIKit'

--- a/FirebaseUI.xcodeproj/project.pbxproj
+++ b/FirebaseUI.xcodeproj/project.pbxproj
@@ -1930,7 +1930,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "";
@@ -1974,7 +1974,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_CFLAGS = "";
 				SDKROOT = iphoneos;
@@ -2020,7 +2020,7 @@
 		8DBA0F551D872E1C00D113D3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -2033,7 +2033,7 @@
 		8DBA0F561D872E1C00D113D3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -2046,7 +2046,7 @@
 		8DBA0F631D872E2400D113D3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -2059,7 +2059,7 @@
 		8DBA0F641D872E2400D113D3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -2072,7 +2072,7 @@
 		8DBA0F701D872E2E00D113D3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -2085,7 +2085,7 @@
 		8DBA0F711D872E2E00D113D3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -2098,7 +2098,7 @@
 		8DBA0F7D1D872E3500D113D3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -2111,7 +2111,7 @@
 		8DBA0F7E1D872E3500D113D3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/FirebaseUI.xcodeproj/project.pbxproj
+++ b/FirebaseUI.xcodeproj/project.pbxproj
@@ -85,6 +85,27 @@
 		8DA941EF1D67951B00CD3685 /* FirebaseArrayTestUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DA941EB1D67951B00CD3685 /* FirebaseArrayTestUtils.m */; };
 		8DA941F01D67951B00CD3685 /* FirebaseCollectionViewDataSourceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DA941EC1D67951B00CD3685 /* FirebaseCollectionViewDataSourceTest.m */; };
 		8DA941F11D67951B00CD3685 /* FirebaseTableViewDataSourceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DA941ED1D67951B00CD3685 /* FirebaseTableViewDataSourceTest.m */; };
+		8DBA0F7F1D872E4300D113D3 /* FirebaseArray.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DA941431D678E3200CD3685 /* FirebaseArray.m */; };
+		8DBA0F801D872E4700D113D3 /* FirebaseCollectionViewDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DA941441D678E3200CD3685 /* FirebaseCollectionViewDataSource.m */; };
+		8DBA0F811D872E4B00D113D3 /* FirebaseDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DA941451D678E3200CD3685 /* FirebaseDataSource.m */; };
+		8DBA0F821D872E4E00D113D3 /* FirebaseTableViewDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DA941461D678E3200CD3685 /* FirebaseTableViewDataSource.m */; };
+		8DBA0F831D872E7A00D113D3 /* FIRAuthPickerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DA9414C1D678F5400CD3685 /* FIRAuthPickerViewController.m */; };
+		8DBA0F841D872E8C00D113D3 /* FIRAuthUI.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DA941511D678F5400CD3685 /* FIRAuthUI.m */; };
+		8DBA0F851D872E9000D113D3 /* FIRAuthUIBaseViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DA941531D678F5400CD3685 /* FIRAuthUIBaseViewController.m */; };
+		8DBA0F861D872E9300D113D3 /* FIRAuthUIErrors.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DA941551D678F5400CD3685 /* FIRAuthUIErrors.m */; };
+		8DBA0F871D872E9500D113D3 /* FIRAuthUIErrorUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DA941571D678F5400CD3685 /* FIRAuthUIErrorUtils.m */; };
+		8DBA0F881D872E9800D113D3 /* FIRAuthUISignInButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DA941591D678F5400CD3685 /* FIRAuthUISignInButton.m */; };
+		8DBA0F891D872E9A00D113D3 /* FIRAuthUIStrings.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DA9415B1D678F5400CD3685 /* FIRAuthUIStrings.m */; };
+		8DBA0F8A1D872E9E00D113D3 /* FIRAuthUITableHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DA9415D1D678F5400CD3685 /* FIRAuthUITableHeaderView.m */; };
+		8DBA0F8B1D872EAA00D113D3 /* FIRAuthUITableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DA9415F1D678F5400CD3685 /* FIRAuthUITableViewCell.m */; };
+		8DBA0F8C1D872EAA00D113D3 /* FIRAuthUIUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DA941621D678F5400CD3685 /* FIRAuthUIUtils.m */; };
+		8DBA0F8D1D872EAA00D113D3 /* FIREmailEntryViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DA941641D678F5400CD3685 /* FIREmailEntryViewController.m */; };
+		8DBA0F8E1D872EAA00D113D3 /* FIRPasswordRecoveryViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DA941671D678F5400CD3685 /* FIRPasswordRecoveryViewController.m */; };
+		8DBA0F8F1D872EAA00D113D3 /* FIRPasswordSignInViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DA9416A1D678F5400CD3685 /* FIRPasswordSignInViewController.m */; };
+		8DBA0F901D872EAA00D113D3 /* FIRPasswordSignUpViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DA9416D1D678F5400CD3685 /* FIRPasswordSignUpViewController.m */; };
+		8DBA0F911D872EAA00D113D3 /* FIRPasswordVerificationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DA941701D678F5400CD3685 /* FIRPasswordVerificationViewController.m */; };
+		8DBA0F921D872EBA00D113D3 /* FIRFacebookAuthUI.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DA941AF1D67908E00CD3685 /* FIRFacebookAuthUI.m */; };
+		8DBA0F931D872EC100D113D3 /* FIRGoogleAuthUI.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DA941B31D6790E900CD3685 /* FIRGoogleAuthUI.m */; };
 		8DCC4FA81D678CC400B0D3C4 /* FirebaseDatabaseUI.h in Headers */ = {isa = PBXBuildFile; fileRef = 8DCC4FA71D678CC400B0D3C4 /* FirebaseDatabaseUI.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8DCC4FD01D678CDC00B0D3C4 /* FirebaseAuthUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DCC4FCF1D678CDC00B0D3C4 /* FirebaseAuthUITests.m */; };
 		8DCC4FEC1D678CE800B0D3C4 /* FirebaseFacebookAuthUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8DCC4FEB1D678CE800B0D3C4 /* FirebaseFacebookAuthUITests.m */; };
@@ -163,6 +184,45 @@
 			remoteInfo = FirebaseGoogleAuthUI;
 		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		8DBA0F4D1D872E1C00D113D3 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8DBA0F5A1D872E2400D113D3 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8DBA0F671D872E2E00D113D3 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8DBA0F741D872E3500D113D3 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		8D2A84A61D678B2B0058DF04 /* FirebaseUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FirebaseUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -244,6 +304,10 @@
 		8DA941EB1D67951B00CD3685 /* FirebaseArrayTestUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FirebaseArrayTestUtils.m; sourceTree = "<group>"; };
 		8DA941EC1D67951B00CD3685 /* FirebaseCollectionViewDataSourceTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FirebaseCollectionViewDataSourceTest.m; sourceTree = "<group>"; };
 		8DA941ED1D67951B00CD3685 /* FirebaseTableViewDataSourceTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FirebaseTableViewDataSourceTest.m; sourceTree = "<group>"; };
+		8DBA0F4F1D872E1C00D113D3 /* libDatabase.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libDatabase.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		8DBA0F5C1D872E2400D113D3 /* libAuth.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libAuth.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		8DBA0F691D872E2E00D113D3 /* libFacebook.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libFacebook.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		8DBA0F761D872E3500D113D3 /* libGoogle.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libGoogle.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		8DCC4FA51D678CC400B0D3C4 /* FirebaseDatabaseUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FirebaseDatabaseUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8DCC4FA71D678CC400B0D3C4 /* FirebaseDatabaseUI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FirebaseDatabaseUI.h; sourceTree = "<group>"; };
 		8DCC4FA91D678CC400B0D3C4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -271,6 +335,34 @@
 
 /* Begin PBXFrameworksBuildPhase section */
 		8D2A84A21D678B2B0058DF04 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8DBA0F4C1D872E1C00D113D3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8DBA0F591D872E2400D113D3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8DBA0F661D872E2E00D113D3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8DBA0F731D872E3500D113D3 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -365,6 +457,10 @@
 				8DCC4FE61D678CE800B0D3C4 /* FirebaseFacebookAuthUITests.xctest */,
 				8DCC4FF91D678CF500B0D3C4 /* FirebaseGoogleAuthUI.framework */,
 				8DCC50021D678CF500B0D3C4 /* FirebaseGoogleAuthUITests.xctest */,
+				8DBA0F4F1D872E1C00D113D3 /* libDatabase.a */,
+				8DBA0F5C1D872E2400D113D3 /* libAuth.a */,
+				8DBA0F691D872E2E00D113D3 /* libFacebook.a */,
+				8DBA0F761D872E3500D113D3 /* libGoogle.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -706,6 +802,82 @@
 			productReference = 8D2A84A61D678B2B0058DF04 /* FirebaseUI.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		8DBA0F4E1D872E1C00D113D3 /* Database */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8DBA0F571D872E1C00D113D3 /* Build configuration list for PBXNativeTarget "Database" */;
+			buildPhases = (
+				1E306FF97634A37C657C646D /* [CP] Check Pods Manifest.lock */,
+				8DBA0F4B1D872E1C00D113D3 /* Sources */,
+				8DBA0F4C1D872E1C00D113D3 /* Frameworks */,
+				8DBA0F4D1D872E1C00D113D3 /* CopyFiles */,
+				C8BD067A70D68B90BD201A7E /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Database;
+			productName = Database;
+			productReference = 8DBA0F4F1D872E1C00D113D3 /* libDatabase.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		8DBA0F5B1D872E2400D113D3 /* Auth */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8DBA0F621D872E2400D113D3 /* Build configuration list for PBXNativeTarget "Auth" */;
+			buildPhases = (
+				57FFCF324658EFAA033B043B /* [CP] Check Pods Manifest.lock */,
+				8DBA0F581D872E2400D113D3 /* Sources */,
+				8DBA0F591D872E2400D113D3 /* Frameworks */,
+				8DBA0F5A1D872E2400D113D3 /* CopyFiles */,
+				E54F12A0487DA9EBEEFD6E56 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Auth;
+			productName = Auth;
+			productReference = 8DBA0F5C1D872E2400D113D3 /* libAuth.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		8DBA0F681D872E2E00D113D3 /* Facebook */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8DBA0F6F1D872E2E00D113D3 /* Build configuration list for PBXNativeTarget "Facebook" */;
+			buildPhases = (
+				8CF44A5719E2CAD85E2CC637 /* [CP] Check Pods Manifest.lock */,
+				8DBA0F651D872E2E00D113D3 /* Sources */,
+				8DBA0F661D872E2E00D113D3 /* Frameworks */,
+				8DBA0F671D872E2E00D113D3 /* CopyFiles */,
+				B3E4D5225350A6A9994F49FD /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Facebook;
+			productName = Facebook;
+			productReference = 8DBA0F691D872E2E00D113D3 /* libFacebook.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		8DBA0F751D872E3500D113D3 /* Google */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8DBA0F7C1D872E3500D113D3 /* Build configuration list for PBXNativeTarget "Google" */;
+			buildPhases = (
+				EB3A9733EC9A757DFF6623DA /* [CP] Check Pods Manifest.lock */,
+				8DBA0F721D872E3500D113D3 /* Sources */,
+				8DBA0F731D872E3500D113D3 /* Frameworks */,
+				8DBA0F741D872E3500D113D3 /* CopyFiles */,
+				04A6DD897C4487F3BCEC184B /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Google;
+			productName = Google;
+			productReference = 8DBA0F761D872E3500D113D3 /* libGoogle.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 		8DCC4FA41D678CC400B0D3C4 /* FirebaseDatabaseUI */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8DCC4FBA1D678CC400B0D3C4 /* Build configuration list for PBXNativeTarget "FirebaseDatabaseUI" */;
@@ -884,6 +1056,18 @@
 					8D2A84A51D678B2B0058DF04 = {
 						CreatedOnToolsVersion = 7.3.1;
 					};
+					8DBA0F4E1D872E1C00D113D3 = {
+						CreatedOnToolsVersion = 7.3.1;
+					};
+					8DBA0F5B1D872E2400D113D3 = {
+						CreatedOnToolsVersion = 7.3.1;
+					};
+					8DBA0F681D872E2E00D113D3 = {
+						CreatedOnToolsVersion = 7.3.1;
+					};
+					8DBA0F751D872E3500D113D3 = {
+						CreatedOnToolsVersion = 7.3.1;
+					};
 					8DCC4FA41D678CC400B0D3C4 = {
 						CreatedOnToolsVersion = 7.3.1;
 					};
@@ -931,6 +1115,10 @@
 				8DCC4FE51D678CE800B0D3C4 /* FirebaseFacebookAuthUITests */,
 				8DCC4FF81D678CF500B0D3C4 /* FirebaseGoogleAuthUI */,
 				8DCC50011D678CF500B0D3C4 /* FirebaseGoogleAuthUITests */,
+				8DBA0F4E1D872E1C00D113D3 /* Database */,
+				8DBA0F5B1D872E2400D113D3 /* Auth */,
+				8DBA0F681D872E2E00D113D3 /* Facebook */,
+				8DBA0F751D872E3500D113D3 /* Google */,
 			);
 		};
 /* End PBXProject section */
@@ -1027,6 +1215,21 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		04A6DD897C4487F3BCEC184B /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Google/Pods-Google-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		0A5F7912352E8D5E56852548 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1117,6 +1320,21 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
+		1E306FF97634A37C657C646D /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
 		23889266231F83F5AEBA76A9 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1192,6 +1410,21 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-FirebaseFacebookAuthUITests/Pods-FirebaseFacebookAuthUITests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		57FFCF324658EFAA033B043B /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
 		5CF7EAA6702A0FB3195DFCC2 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1252,6 +1485,21 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-FirebaseFacebookAuthUI/Pods-FirebaseFacebookAuthUI-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		8CF44A5719E2CAD85E2CC637 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
 		935EEE7BAB2019F4C23E4780 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1265,6 +1513,21 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-FirebaseAuthUI/Pods-FirebaseAuthUI-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B3E4D5225350A6A9994F49FD /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Facebook/Pods-Facebook-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		B569729EEA3A20D79B446555 /* [CP] Copy Pods Resources */ = {
@@ -1312,6 +1575,21 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
+		C8BD067A70D68B90BD201A7E /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Database/Pods-Database-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		DE99744A3C67AE198C9EA801 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1327,6 +1605,21 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-FirebaseGoogleAuthUITests/Pods-FirebaseGoogleAuthUITests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		E54F12A0487DA9EBEEFD6E56 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Auth/Pods-Auth-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		E9C24E487689B9B7FD91F1AF /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1340,6 +1633,21 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-FirebaseUI/Pods-FirebaseUI-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		EB3A9733EC9A757DFF6623DA /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		F0067D3BF3D921EB66AB571B /* [CP] Copy Pods Resources */ = {
@@ -1364,6 +1672,55 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8DBA0F4B1D872E1C00D113D3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8DBA0F801D872E4700D113D3 /* FirebaseCollectionViewDataSource.m in Sources */,
+				8DBA0F7F1D872E4300D113D3 /* FirebaseArray.m in Sources */,
+				8DBA0F811D872E4B00D113D3 /* FirebaseDataSource.m in Sources */,
+				8DBA0F821D872E4E00D113D3 /* FirebaseTableViewDataSource.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8DBA0F581D872E2400D113D3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8DBA0F8B1D872EAA00D113D3 /* FIRAuthUITableViewCell.m in Sources */,
+				8DBA0F8F1D872EAA00D113D3 /* FIRPasswordSignInViewController.m in Sources */,
+				8DBA0F851D872E9000D113D3 /* FIRAuthUIBaseViewController.m in Sources */,
+				8DBA0F881D872E9800D113D3 /* FIRAuthUISignInButton.m in Sources */,
+				8DBA0F8D1D872EAA00D113D3 /* FIREmailEntryViewController.m in Sources */,
+				8DBA0F8A1D872E9E00D113D3 /* FIRAuthUITableHeaderView.m in Sources */,
+				8DBA0F831D872E7A00D113D3 /* FIRAuthPickerViewController.m in Sources */,
+				8DBA0F901D872EAA00D113D3 /* FIRPasswordSignUpViewController.m in Sources */,
+				8DBA0F861D872E9300D113D3 /* FIRAuthUIErrors.m in Sources */,
+				8DBA0F911D872EAA00D113D3 /* FIRPasswordVerificationViewController.m in Sources */,
+				8DBA0F871D872E9500D113D3 /* FIRAuthUIErrorUtils.m in Sources */,
+				8DBA0F8E1D872EAA00D113D3 /* FIRPasswordRecoveryViewController.m in Sources */,
+				8DBA0F8C1D872EAA00D113D3 /* FIRAuthUIUtils.m in Sources */,
+				8DBA0F841D872E8C00D113D3 /* FIRAuthUI.m in Sources */,
+				8DBA0F891D872E9A00D113D3 /* FIRAuthUIStrings.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8DBA0F651D872E2E00D113D3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8DBA0F921D872EBA00D113D3 /* FIRFacebookAuthUI.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8DBA0F721D872E3500D113D3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8DBA0F931D872EC100D113D3 /* FIRGoogleAuthUI.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1660,6 +2017,110 @@
 			};
 			name = Release;
 		};
+		8DBA0F551D872E1C00D113D3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		8DBA0F561D872E1C00D113D3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		8DBA0F631D872E2400D113D3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		8DBA0F641D872E2400D113D3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		8DBA0F701D872E2E00D113D3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		8DBA0F711D872E2E00D113D3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		8DBA0F7D1D872E3500D113D3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		8DBA0F7E1D872E3500D113D3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
 		8DCC4FB61D678CC400B0D3C4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1889,6 +2350,42 @@
 			buildConfigurations = (
 				8D2A84BB1D678B2B0058DF04 /* Debug */,
 				8D2A84BC1D678B2B0058DF04 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8DBA0F571D872E1C00D113D3 /* Build configuration list for PBXNativeTarget "Database" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8DBA0F551D872E1C00D113D3 /* Debug */,
+				8DBA0F561D872E1C00D113D3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8DBA0F621D872E2400D113D3 /* Build configuration list for PBXNativeTarget "Auth" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8DBA0F631D872E2400D113D3 /* Debug */,
+				8DBA0F641D872E2400D113D3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8DBA0F6F1D872E2E00D113D3 /* Build configuration list for PBXNativeTarget "Facebook" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8DBA0F701D872E2E00D113D3 /* Debug */,
+				8DBA0F711D872E2E00D113D3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8DBA0F7C1D872E3500D113D3 /* Build configuration list for PBXNativeTarget "Google" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8DBA0F7D1D872E3500D113D3 /* Debug */,
+				8DBA0F7E1D872E3500D113D3 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Podfile
+++ b/Podfile
@@ -51,3 +51,24 @@ target 'FirebaseGoogleAuthUI' do
   end
 end
 
+target 'Database' do
+  # Pods for Database
+  pod 'Firebase/Database'
+end
+
+target 'Auth' do
+  # Pods for Auth
+  pod 'Firebase/Auth'
+end
+
+target 'Facebook' do
+  # Pods for Facebook Auth
+  pod 'Firebase/Auth'
+  pod 'FBSDKLoginKit', '~> 4.0'
+end
+
+target 'Google' do
+  # Pods for Google Auth
+  pod 'Firebase/Auth'
+  pod 'GoogleSignIn', '~> 4.0'
+end

--- a/samples/swift/uidemo.xcodeproj/project.pbxproj
+++ b/samples/swift/uidemo.xcodeproj/project.pbxproj
@@ -7,8 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		433E703692A371C84E532086 /* Pods_uidemoTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 45B7A43C757A128633BBDAFF /* Pods_uidemoTests.framework */; };
-		6001626D469756A781BC0C1D /* Pods_uidemo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C0B23F4C2DB9A671802E1E31 /* Pods_uidemo.framework */; };
 		8D16073E1D492B200069E4F5 /* AuthViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D16073D1D492B200069E4F5 /* AuthViewController.swift */; };
 		8DABC9891D3D82D600453807 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DABC9881D3D82D600453807 /* AppDelegate.swift */; };
 		8DABC98B1D3D82D600453807 /* MenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DABC98A1D3D82D600453807 /* MenuViewController.swift */; };
@@ -19,6 +17,7 @@
 		8DABC9A91D3D872C00453807 /* Sample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DABC9A81D3D872C00453807 /* Sample.swift */; };
 		8DABC9AB1D3D947300453807 /* SampleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DABC9AA1D3D947300453807 /* SampleCell.swift */; };
 		8DABC9AD1D3D9EAF00453807 /* ChatViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DABC9AC1D3D9EAF00453807 /* ChatViewController.swift */; };
+		8DD51E371D873B0D00E2CA51 /* UIStoryboardExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DD51E361D873B0D00E2CA51 /* UIStoryboardExtension.swift */; };
 		8DDF1AE51D3FF67D001F1160 /* ChatCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DDF1AE41D3FF67D001F1160 /* ChatCollectionViewCell.swift */; };
 		C3F23ECD1D80F3300020509F /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = C3F23ECC1D80F3300020509F /* GoogleService-Info.plist */; };
 /* End PBXBuildFile section */
@@ -34,10 +33,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		45B7A43C757A128633BBDAFF /* Pods_uidemoTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_uidemoTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		4C4F100F73AB7282D3071228 /* Pods-uidemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-uidemo.release.xcconfig"; path = "Pods/Target Support Files/Pods-uidemo/Pods-uidemo.release.xcconfig"; sourceTree = "<group>"; };
-		74B1CFAE0F3BD0D456DFCC76 /* Pods-uidemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-uidemoTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-uidemoTests/Pods-uidemoTests.debug.xcconfig"; sourceTree = "<group>"; };
-		8C5E1A3D7FD94BB28A092EBC /* Pods-uidemoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-uidemoTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-uidemoTests/Pods-uidemoTests.release.xcconfig"; sourceTree = "<group>"; };
 		8D16073D1D492B200069E4F5 /* AuthViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthViewController.swift; sourceTree = "<group>"; };
 		8DABC9851D3D82D600453807 /* uidemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = uidemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8DABC9881D3D82D600453807 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -52,10 +47,9 @@
 		8DABC9A81D3D872C00453807 /* Sample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sample.swift; sourceTree = "<group>"; };
 		8DABC9AA1D3D947300453807 /* SampleCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SampleCell.swift; sourceTree = "<group>"; };
 		8DABC9AC1D3D9EAF00453807 /* ChatViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatViewController.swift; sourceTree = "<group>"; };
+		8DD51E361D873B0D00E2CA51 /* UIStoryboardExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIStoryboardExtension.swift; sourceTree = "<group>"; };
 		8DDF1AE41D3FF67D001F1160 /* ChatCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatCollectionViewCell.swift; sourceTree = "<group>"; };
-		C0B23F4C2DB9A671802E1E31 /* Pods_uidemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_uidemo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C3F23ECC1D80F3300020509F /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
-		CB9DA206245B6BEB7500A66A /* Pods-uidemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-uidemo.debug.xcconfig"; path = "Pods/Target Support Files/Pods-uidemo/Pods-uidemo.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -63,7 +57,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6001626D469756A781BC0C1D /* Pods_uidemo.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -71,7 +64,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				433E703692A371C84E532086 /* Pods_uidemoTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -94,8 +86,6 @@
 				8DABC9871D3D82D600453807 /* uidemo */,
 				8DABC99C1D3D82D600453807 /* uidemoTests */,
 				8DABC9861D3D82D600453807 /* Products */,
-				94250E737FC3C4C5C6F2681A /* Pods */,
-				F6DBA04B6C438DF62F38F922 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -115,6 +105,7 @@
 				8DABC98A1D3D82D600453807 /* MenuViewController.swift */,
 				8DABC9AA1D3D947300453807 /* SampleCell.swift */,
 				8DABC9A81D3D872C00453807 /* Sample.swift */,
+				8DD51E361D873B0D00E2CA51 /* UIStoryboardExtension.swift */,
 				8DD17C951D4BCC6500E850E4 /* AuthSample */,
 				8D643F0F1D4827F10081F979 /* ChatSample */,
 				8DABC98C1D3D82D600453807 /* Main.storyboard */,
@@ -140,26 +131,6 @@
 				8D16073D1D492B200069E4F5 /* AuthViewController.swift */,
 			);
 			name = AuthSample;
-			sourceTree = "<group>";
-		};
-		94250E737FC3C4C5C6F2681A /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				CB9DA206245B6BEB7500A66A /* Pods-uidemo.debug.xcconfig */,
-				4C4F100F73AB7282D3071228 /* Pods-uidemo.release.xcconfig */,
-				74B1CFAE0F3BD0D456DFCC76 /* Pods-uidemoTests.debug.xcconfig */,
-				8C5E1A3D7FD94BB28A092EBC /* Pods-uidemoTests.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
-		F6DBA04B6C438DF62F38F922 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				C0B23F4C2DB9A671802E1E31 /* Pods_uidemo.framework */,
-				45B7A43C757A128633BBDAFF /* Pods_uidemoTests.framework */,
-			);
-			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -365,6 +336,7 @@
 			files = (
 				8DABC98B1D3D82D600453807 /* MenuViewController.swift in Sources */,
 				8DABC9AB1D3D947300453807 /* SampleCell.swift in Sources */,
+				8DD51E371D873B0D00E2CA51 /* UIStoryboardExtension.swift in Sources */,
 				8DABC9A91D3D872C00453807 /* Sample.swift in Sources */,
 				8D16073E1D492B200069E4F5 /* AuthViewController.swift in Sources */,
 				8DABC9AD1D3D9EAF00453807 /* ChatViewController.swift in Sources */,
@@ -415,6 +387,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				BITCODE_GENERATION_MODE = bitcode;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -461,6 +434,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				BITCODE_GENERATION_MODE = bitcode;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -498,9 +472,9 @@
 		};
 		8DABC9A31D3D82D600453807 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CB9DA206245B6BEB7500A66A /* Pods-uidemo.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				BITCODE_GENERATION_MODE = "";
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = uidemo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -513,9 +487,9 @@
 		};
 		8DABC9A41D3D82D600453807 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4C4F100F73AB7282D3071228 /* Pods-uidemo.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				BITCODE_GENERATION_MODE = "";
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = uidemo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -527,7 +501,6 @@
 		};
 		8DABC9A61D3D82D600453807 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 74B1CFAE0F3BD0D456DFCC76 /* Pods-uidemoTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				INFOPLIST_FILE = uidemoTests/Info.plist;
@@ -540,7 +513,6 @@
 		};
 		8DABC9A71D3D82D600453807 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8C5E1A3D7FD94BB28A092EBC /* Pods-uidemoTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				INFOPLIST_FILE = uidemoTests/Info.plist;


### PR DESCRIPTION
We can't use dylibs as long as Firebase is shipped as a static dependency, otherwise it gets linked into each dylib and creates sadness when trying to use multiple dylibs together.