### PR TITLE
Allow elements to be moved to start of FirebaseArray (potential fix for #129)

### DIFF
--- a/FirebaseDatabaseUI/FirebaseArray.m
+++ b/FirebaseDatabaseUI/FirebaseArray.m
@@ -124,9 +124,11 @@
         [self.snapshots removeObjectAtIndex:fromIndex];
 
         NSUInteger toIndex = 0;
-        NSUInteger prevIndex = [self indexForKey:previousChildKey];
-        if (prevIndex != NSNotFound) {
-          toIndex = prevIndex + 1;
+        if (previousChildKey != nil) {
+            NSUInteger prevIndex = [self indexForKey:previousChildKey];
+            if (prevIndex != NSNotFound) {
+                toIndex = prevIndex + 1;
+            }
         }
         [self.snapshots insertObject:snapshot atIndex:toIndex];
 

--- a/FirebaseDatabaseUI/FirebaseArray.m
+++ b/FirebaseDatabaseUI/FirebaseArray.m
@@ -123,7 +123,11 @@
         NSUInteger fromIndex = [self indexForKey:snapshot.key];
         [self.snapshots removeObjectAtIndex:fromIndex];
 
-        NSUInteger toIndex = [self indexForKey:previousChildKey] + 1;
+        NSUInteger toIndex = 0;
+        NSUInteger prevIndex = [self indexForKey:previousChildKey];
+        if (prevIndex != NSNotFound) {
+          toIndex = prevIndex + 1;
+        }
         [self.snapshots insertObject:snapshot atIndex:toIndex];
 
         if ([self.delegate respondsToSelector:@selector(array:didMoveObject:fromIndex:toIndex:)]) {

--- a/FirebaseDatabaseUITests/FirebaseArrayTest.m
+++ b/FirebaseDatabaseUITests/FirebaseArrayTest.m
@@ -378,4 +378,36 @@
   XCTAssert(expectedParametersWereCorrect, @"unexpected parameter in delegate callback");
 }
 
+- (void)testFirebaseArrayCanMoveElementToStart {
+    [self.observable populateWithCount:10];
+    self.snap.key = @"8";
+    
+    // Test delegate
+    __block BOOL delegateWasCalled = NO;
+    __block BOOL expectedParametersWereCorrect = NO;
+    self.arrayDelegate.didMoveObject = ^(FirebaseArray *array, id object, NSUInteger from, NSUInteger to) {
+        // Xcode complains about retain cycles if an XCTAssert is placed in here.
+        delegateWasCalled = YES;
+        expectedParametersWereCorrect = (array == self.firebaseArray &&
+                                         object == self.snap &&
+                                         from == 8 && to == 0);
+    };
+    
+    // Move 8 to the start
+    [self.observable sendEvent:FIRDataEventTypeChildMoved withObject:self.snap previousKey:@"" error:nil];
+    
+    // Array expectation
+    NSArray *items = self.firebaseArray.items;
+    NSArray *expected = @[@"8", @"0", @"1", @"2", @"3", @"4", @"5", @"6", @"7", @"9"];
+    NSMutableArray *result = [NSMutableArray array];
+    for (FUIFakeSnapshot *snapshot in items) {
+        [result addObject:snapshot.key];
+    }
+    XCTAssert([result isEqual:expected], @"expected firebaseArray contents to equal %@, got %@", expected, [result copy]);
+    
+    // Delegate expectations
+    XCTAssert(delegateWasCalled, @"expected delegate to receive callback for deletion");
+    XCTAssert(expectedParametersWereCorrect, @"unexpected parameter in delegate callback");
+}
+
 @end


### PR DESCRIPTION
When using FirebaseTableViewDataSource I was seeing something like the following when moving an object to the start of a list.

`Assertions: failed: caught "NSRangeException", "*** -[__NSArrayM insertObject:atIndex:]: index 9223372036854775807 beyond bounds [0 .. 8]"`

It looks like it was caused by the `FIRDataEventTypeChildMoved` being sent a `previousChildKey` that doesn't exist in the array (presumably ""). This is similar to #129 and is potentially a fix for that.