### PR TITLE
allow consumers to manually set table view and collection view on data sources

### DIFF
--- a/FirebaseDatabaseUI/FUICollectionViewDataSource.h
+++ b/FirebaseDatabaseUI/FUICollectionViewDataSource.h
@@ -37,9 +37,10 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The UICollectionView instance that operations (inserts, removals, moves,
  * etc.) are performed against. The data source does not claim ownership of
- * the collection view it populates.
+ * the collection view it populates. This collection view must be receiving data
+ * from this data source otherwise data inconsistency crashes will occur.
  */
-@property (nonatomic, readonly, weak) UICollectionView *collectionView;
+@property (nonatomic, readwrite, weak, nullable) UICollectionView *collectionView;
 
 /**
  * The callback to populate a subclass of UICollectionViewCell with an object

--- a/FirebaseDatabaseUI/FUITableViewDataSource.h
+++ b/FirebaseDatabaseUI/FUITableViewDataSource.h
@@ -30,15 +30,16 @@ NS_ASSUME_NONNULL_BEGIN
  * FUITableViewDataSource provides a class that conforms to the
  * UITableViewDataSource protocol which allows UITableViews to implement
  * FUITableViewDataSource in order to provide a UITableView synchronized
- * to a Firebase reference or query.
+ * to a Firebase reference or query. 
  */
 @interface FUITableViewDataSource : FUIDataSource<UITableViewDataSource>
 
 /**
  * The UITableView instance that operations (inserts, removals, moves, etc.) are
- * performed against.
+ * performed against. This collection view must be receiving data from
+ * this data source otherwise data inconsistency crashes will occur.
  */
-@property (nonatomic, readonly, weak) UITableView *tableView;
+@property (nonatomic, readwrite, weak, nullable) UITableView *tableView;
 
 /**
  * The callback used by the data source to populate the table view.

--- a/FirebaseDatabaseUI/FUITableViewDataSource.m
+++ b/FirebaseDatabaseUI/FUITableViewDataSource.m
@@ -24,8 +24,6 @@
 
 @interface FUITableViewDataSource ()
 
-@property (nonatomic, readwrite, weak) UITableView *tableView;
-
 @property(strong, nonatomic, readwrite) UITableViewCell *(^populateCell)
   (UITableView *tableView, NSIndexPath *indexPath, FIRDataSnapshot *snap);
 


### PR DESCRIPTION
This avoids an issue where the data source still tries to update the table/collection view after it shouldn't.

Addresses #234.