### PR TITLE
fix bug in FUIIndexArray

### DIFF
--- a/FirebaseDatabaseUI/FUIQueryObserver.m
+++ b/FirebaseDatabaseUI/FUIQueryObserver.m
@@ -58,8 +58,6 @@
     completion(obs, nil, error);
   };
 
-  [obs observeEventType:FIRDataEventTypeChildAdded
-    andPreviousSiblingKeyWithBlock:observerBlock withCancelBlock:cancelBlock];
   [obs observeEventType:FIRDataEventTypeValue
     andPreviousSiblingKeyWithBlock:observerBlock withCancelBlock:cancelBlock];
   return obs;

--- a/FirebaseDatabaseUITests/FUIDatabaseTestUtils.m
+++ b/FirebaseDatabaseUITests/FUIDatabaseTestUtils.m
@@ -176,6 +176,11 @@
       id value = self.contents[contentKey];
       FUIFakeSnapshot *snap = [[FUIFakeSnapshot alloc] initWithKey:contentKey value:value];
       [self sendEvent:FIRDataEventTypeChildAdded withObject:snap previousKey:previousKey error:nil];
+
+      // Send a value event, since this is a complete snapshot.
+      // TODO: FUIFakeSnapshot currently only represents dictionary types, though snapshots can
+      // have array, string, or number values as well. Tests need to be written for these.
+      [self sendEvent:FIRDataEventTypeValue withObject:snap previousKey:previousKey error:nil];
       previousKey = contentKey;
     }
   }

--- a/FirebaseDatabaseUITests/FUIIndexArrayTest.m
+++ b/FirebaseDatabaseUITests/FUIIndexArrayTest.m
@@ -60,7 +60,7 @@ static inline NSDictionary *database() {
   self.index = [[FUITestObservable alloc] initWithDictionary:database()[@"index"]];
   self.data = [[FUITestObservable alloc] initWithDictionary:database()[@"data"]];
   self.array = [[FUIIndexArray alloc] initWithIndex:self.index
-                                                    data:self.data];
+                                               data:self.data];
   self.arrayDelegate = [[FUIIndexArrayTestDelegate alloc] init];
   self.array.delegate = self.arrayDelegate;
   self.dict = [database() mutableCopy];


### PR DESCRIPTION
Fixes an issue #244 where FUIQueryObserver would accidentally add children of a snap as complete snapshots until the full snapshot was returned.