### PR TITLE
Support changed Twitter.h to TWTRTwitter.h

### DIFF
--- a/FirebaseTwitterAuthUI/FUITwitterAuth.m
+++ b/FirebaseTwitterAuthUI/FUITwitterAuth.m
@@ -18,7 +18,8 @@
 #import <FirebaseAuth/FIRTwitterAuthProvider.h>
 #import <FirebaseAuthUI/FUIAuthBaseViewController.h>
 #import <FirebaseAuthUI/FUIAuthErrorUtils.h>
-#import <TwitterKit/TwitterKit.h>
+#import <TwitterCore/TwitterCore.h>
+#import <TwitterKit/TWTRTwitter.h>
 #import "FUIAuthBaseViewController_Internal.h"
 #import "FUIAuthStrings.h"
 #import "FUIAuthUtils.h"

--- a/FirebaseTwitterAuthUITests/FirebaseTwitterAuthUITests.m
+++ b/FirebaseTwitterAuthUITests/FirebaseTwitterAuthUITests.m
@@ -23,7 +23,7 @@
 #import <FirebaseTwitterAuthUI/FirebaseTwitterAuthUI.h>
 #import <OCMock/OCMock.h>
 #import <TwitterCore/TwitterCore.h>
-#import <TwitterKit/TwitterKit.h>
+#import <TwitterKit/TWTRTwitter.h>
 #import <XCTest/XCTest.h>
 
 @interface FUITwitterAuth (Testing)

--- a/Podfile
+++ b/Podfile
@@ -144,6 +144,7 @@ target 'Twitter' do
 
   # Pods for Twitter Auth
   pod 'FirebaseAuth'
+  pod 'TwitterCore', '~> 3.0'
   pod 'TwitterKit', '~> 3.0'
 end
 


### PR DESCRIPTION
Fixes issue #380. If ```FirebaseUI``` is included in a project that runs ```pod  update```, an error no longer occurs from FirebaseUI with this change.

```TwitterCore``` is necessary to be imported on ```FUITwitterAuth.m``` because ```TWTRLogInErrorCodeCancelled``` is in ```TwitterCore```.