### PR TITLE
Facebook support for email_in_user_when_upgrading

### DIFF
--- a/FirebaseAuthUI/FUIAuth.m
+++ b/FirebaseAuthUI/FUIAuth.m
@@ -302,7 +302,7 @@ static NSString *const kFirebaseAuthUIFrameworkMarker = @"FirebaseUI-iOS";
     NSString *existingFederatedProviderID = [self federatedAuthProviderFromProviders:providers];
     // Set of providers which can be auto-linked
     NSSet *supportedProviders =
-        [NSSet setWithObjects:FIRGoogleAuthProviderID,FIRFacebookAuthProviderID, nil];
+        [NSSet setWithObjects:FIRGoogleAuthProviderID, FIRFacebookAuthProviderID, nil];
     if ([supportedProviders containsObject:existingFederatedProviderID]) {
       id<FUIAuthProvider> authProviderUI;
       // Retrieve the FUIAuthProvider instance from FUIAuth for the existing provider ID.
@@ -314,10 +314,10 @@ static NSString *const kFirebaseAuthUIFrameworkMarker = @"FirebaseUI-iOS";
       }
       [authProviderUI signOut];
       [authProviderUI signInWithDefaultValue:emailHint
-                      presentingViewController:presentingViewController
-                                    completion:^(FIRAuthCredential *_Nullable credential,
-                                                 NSError *_Nullable error,
-                                                 FIRAuthResultCallback  _Nullable result) {
+                    presentingViewController:presentingViewController
+                                  completion:^(FIRAuthCredential *_Nullable credential,
+                                               NSError *_Nullable error,
+                                               FIRAuthResultCallback  _Nullable result) {
         if (error) {
           completion(nil, error);
           return;

--- a/FirebaseAuthUI/FUIAuth.m
+++ b/FirebaseAuthUI/FUIAuth.m
@@ -295,18 +295,25 @@ static NSString *const kFirebaseAuthUIFrameworkMarker = @"FirebaseUI-iOS";
 
   [self.auth fetchProvidersForEmail:emailHint completion:^(NSArray<NSString *> *_Nullable providers,
                                                            NSError *_Nullable error) {
-    NSString *federatedProviderID = [self federatedAuthProviderFromProviders:providers];
-    // Google case
-    if ([federatedProviderID isEqualToString:FIRGoogleAuthProviderID]) {
-      id<FUIAuthProvider> googleProviderUI;
+    if (error) {
+      completion(nil, error);
+      return;
+    }
+    NSString *existingFederatedProviderID = [self federatedAuthProviderFromProviders:providers];
+    // Set of providers which can be auto-linked
+    NSSet *supportedProviders =
+        [NSSet setWithObjects:FIRGoogleAuthProviderID,FIRFacebookAuthProviderID, nil];
+    if ([supportedProviders containsObject:existingFederatedProviderID]) {
+      id<FUIAuthProvider> authProviderUI;
+      // Retrieve the FUIAuthProvider instance from FUIAuth for the existing provider ID.
       for (id<FUIAuthProvider> provider in self.providers) {
-        if ([provider.providerID isEqualToString:FIRGoogleAuthProviderID]) {
-          googleProviderUI = provider;
+        if ([provider.providerID isEqualToString:existingFederatedProviderID]) {
+          authProviderUI = provider;
           break;
         }
       }
-      [googleProviderUI signOut];
-      [googleProviderUI signInWithDefaultValue:emailHint
+      [authProviderUI signOut];
+      [authProviderUI signInWithDefaultValue:emailHint
                       presentingViewController:presentingViewController
                                     completion:^(FIRAuthCredential *_Nullable credential,
                                                  NSError *_Nullable error,

--- a/FirebaseGoogleAuthUI/FUIGoogleAuth.m
+++ b/FirebaseGoogleAuthUI/FUIGoogleAuth.m
@@ -55,6 +55,11 @@ static NSString *const kSignInWithGoogle = @"SignInWithGoogle";
       @brief The callback which should be invoked when the sign in flow completes (or is cancelled.)
    */
   FIRAuthProviderSignInCompletionBlock _pendingSignInCallback;
+
+  /** @var _email
+      @brief The email address associated with this account.
+   */
+  NSString *_email;
 }
 
 - (instancetype)init {
@@ -140,6 +145,10 @@ static NSString *const kSignInWithGoogle = @"SignInWithGoogle";
   return [signIn handleURL:URL sourceApplication:sourceApplication annotation:nil];
 }
 
+- (NSString *)email {
+  return _email;
+}
+
 #pragma mark - GIDSignInDelegate methods
 
 - (void)signIn:(GIDSignIn *)signIn
@@ -158,6 +167,7 @@ static NSString *const kSignInWithGoogle = @"SignInWithGoogle";
     }
     return;
   }
+  _email = user.profile.email;
   UIActivityIndicatorView *activityView =
       [FUIAuthBaseViewController addActivityIndicator:_presentingViewController.view];
   [activityView startAnimating];


### PR DESCRIPTION
Adds support for Facebook when autolinking an existing user to a new federated user. Tested with Google and Facebook auth credentials for now.