### PR TITLE
Adds email/password “email-already-in-use” flow when upgrading to a federated credential

### DIFF
--- a/FirebaseAuthUI/FUIAuth.m
+++ b/FirebaseAuthUI/FUIAuth.m
@@ -331,7 +331,9 @@ static NSString *const kFirebaseAuthUIFrameworkMarker = @"FirebaseUI-iOS";
                                                  NSError *_Nullable error,
                                                  FIRAuthResultCallback  _Nullable result) {
           if (error) {
-            completion(nil, error);
+            if (completion) {
+              completion(nil, error);
+            }
             return;
           }
           [tempAuth signInAndRetrieveDataWithCredential:credential completion:completion];

--- a/FirebaseAuthUI/FUIAuth.m
+++ b/FirebaseAuthUI/FUIAuth.m
@@ -313,7 +313,7 @@ static NSString *const kFirebaseAuthUIFrameworkMarker = @"FirebaseUI-iOS";
         // Email password sign-in
         FUIPasswordSignInViewController *controller =
             [[FUIPasswordSignInViewController alloc] initWithAuthUI:authUI email:emailHint];
-        [controller setOnDismissCallback:completion];
+        controller.onDismissCallback = completion;
         [presentingViewController pushViewController:controller];
       } else {
         id<FUIAuthProvider> authProviderUI;

--- a/FirebaseAuthUI/FUIAuth.m
+++ b/FirebaseAuthUI/FUIAuth.m
@@ -28,6 +28,7 @@
 #import "FUIAuthStrings.h"
 #import "FUIGoogleAuth.h"
 #import "FUIEmailEntryViewController.h"
+#import "FUIPasswordSignInViewController_Internal.h"
 #import "FUIPasswordVerificationViewController.h"
 
 /** @var kAppNameCodingKey
@@ -154,7 +155,7 @@ static NSString *const kFirebaseAuthUIFrameworkMarker = @"FirebaseUI-iOS";
 }
 
 - (void)signInWithProviderUI:(id<FUIAuthProvider>)providerUI
-    presentingViewController:(UIViewController *)presentingViewController
+    presentingViewController:(FUIAuthBaseViewController *)presentingViewController
                 defaultValue:(nullable NSString *)defaultValue {
 
   // Sign out first to make sure sign in starts with a clean state.
@@ -280,7 +281,7 @@ static NSString *const kFirebaseAuthUIFrameworkMarker = @"FirebaseUI-iOS";
 }
 
 - (void)signInWithEmailHint:(NSString *)emailHint
-   presentingViewController:(UIViewController *)presentingViewController
+   presentingViewController:(FUIAuthBaseViewController *)presentingViewController
                  completion:(FIRAuthDataResultCallback)completion {
   NSString *kTempApp = @"tempApp";
   FIROptions *options = [FIROptions defaultOptions];
@@ -291,7 +292,7 @@ static NSString *const kFirebaseAuthUIFrameworkMarker = @"FirebaseUI-iOS";
   FIRApp *tempApp = [FIRApp appNamed:kTempApp];
   // Create a new auth instance in order to perform a successful sign-in without losing the
   // currently signed in user on the default auth instance.
-  FIRAuth *auth = [FIRAuth authWithApp:tempApp];
+  FIRAuth *tempAuth = [FIRAuth authWithApp:tempApp];
 
   [self.auth fetchProvidersForEmail:emailHint completion:^(NSArray<NSString *> *_Nullable providers,
                                                            NSError *_Nullable error) {
@@ -299,39 +300,52 @@ static NSString *const kFirebaseAuthUIFrameworkMarker = @"FirebaseUI-iOS";
       completion(nil, error);
       return;
     }
-    NSString *existingFederatedProviderID = [self federatedAuthProviderFromProviders:providers];
-    // Set of providers which can be auto-linked
+    NSString *existingFederatedProviderID = [self authProviderFromProviders:providers];
+    // Set of providers which can be auto-linked.
     NSSet *supportedProviders =
-        [NSSet setWithObjects:FIRGoogleAuthProviderID, FIRFacebookAuthProviderID, nil];
+        [NSSet setWithObjects:FIRGoogleAuthProviderID,
+                              FIRFacebookAuthProviderID,
+                              FIREmailAuthProviderID,
+                              nil];
     if ([supportedProviders containsObject:existingFederatedProviderID]) {
-      id<FUIAuthProvider> authProviderUI;
-      // Retrieve the FUIAuthProvider instance from FUIAuth for the existing provider ID.
-      for (id<FUIAuthProvider> provider in self.providers) {
-        if ([provider.providerID isEqualToString:existingFederatedProviderID]) {
-          authProviderUI = provider;
-          break;
+      if ([existingFederatedProviderID isEqualToString:FIREmailAuthProviderID]) {
+        FUIAuth *authUI = [[FUIAuth alloc]initWithAuth:tempAuth];
+        // Email password sign-in
+        FUIPasswordSignInViewController *controller =
+            [[FUIPasswordSignInViewController alloc] initWithAuthUI:authUI email:emailHint];
+        [controller setOnDismissCallback:completion];
+        [presentingViewController pushViewController:controller];
+      } else {
+        id<FUIAuthProvider> authProviderUI;
+        // Retrieve the FUIAuthProvider instance from FUIAuth for the existing provider ID.
+        for (id<FUIAuthProvider> provider in self.providers) {
+          if ([provider.providerID isEqualToString:existingFederatedProviderID]) {
+            authProviderUI = provider;
+            break;
+          }
         }
+        [authProviderUI signOut];
+        [authProviderUI signInWithDefaultValue:emailHint
+                      presentingViewController:presentingViewController
+                                    completion:^(FIRAuthCredential *_Nullable credential,
+                                                 NSError *_Nullable error,
+                                                 FIRAuthResultCallback  _Nullable result) {
+          if (error) {
+            completion(nil, error);
+            return;
+          }
+          [tempAuth signInAndRetrieveDataWithCredential:credential completion:completion];
+        }];
       }
-      [authProviderUI signOut];
-      [authProviderUI signInWithDefaultValue:emailHint
-                    presentingViewController:presentingViewController
-                                  completion:^(FIRAuthCredential *_Nullable credential,
-                                               NSError *_Nullable error,
-                                               FIRAuthResultCallback  _Nullable result) {
-        if (error) {
-          completion(nil, error);
-          return;
-        }
-
-        [auth signInAndRetrieveDataWithCredential:credential completion:completion];
-      }];
     }
   }];
 }
 
-- (nullable NSString *)federatedAuthProviderFromProviders:(NSArray <NSString *> *) providers {
+- (nullable NSString *)authProviderFromProviders:(NSArray <NSString *> *) providers {
   NSSet *providerSet =
-      [NSSet setWithArray:@[ FIRFacebookAuthProviderID, FIRGoogleAuthProviderID ]];
+      [NSSet setWithArray:@[ FIRFacebookAuthProviderID,
+                             FIRGoogleAuthProviderID,
+                             FIREmailAuthProviderID ]];
   for (NSString *provider in providers) {
     if ( [providerSet containsObject:provider]) {
       return provider;

--- a/FirebaseAuthUI/FUIPasswordSignInViewController.m
+++ b/FirebaseAuthUI/FUIPasswordSignInViewController.m
@@ -14,7 +14,7 @@
 //  limitations under the License.
 //
 
-#import "FUIPasswordSignInViewController.h"
+#import "FUIPasswordSignInViewController_Internal.h"
 
 #import <FirebaseAuth/FirebaseAuth.h>
 #import "FUIAuthBaseViewController_Internal.h"
@@ -59,6 +59,11 @@ static NSString *const kCellReuseIdentifier = @"cellReuseIdentifier";
       @brief The @c UIButton which handles forgot password action.
    */
   __weak IBOutlet UIButton *_forgotPasswordButton;
+
+  /** @var _onDismissCallback
+      @brief The callback to be executed during view controller dismissal.
+   */
+  FIRAuthDataResultCallback _onDismissCallback;
 }
 
 - (instancetype)initWithAuthUI:(FUIAuth *)authUI
@@ -78,7 +83,7 @@ static NSString *const kCellReuseIdentifier = @"cellReuseIdentifier";
                          authUI:authUI];
   if (self) {
     _email = [email copy];
-
+    _onDismissCallback = nil;
     self.title = FUILocalizedString(kStr_SignInTitle);
   }
   return self;
@@ -134,7 +139,11 @@ static NSString *const kCellReuseIdentifier = @"cellReuseIdentifier";
         }
       }
       [self.navigationController dismissViewControllerAnimated:YES completion:^{
-        [self.authUI invokeResultCallbackWithAuthDataResult:authResult error:error];
+        if (self->_onDismissCallback) {
+          self->_onDismissCallback(authResult, error);
+        } else {
+          [self.authUI invokeResultCallbackWithAuthDataResult:authResult error:error];
+        }
       }];
     };
 
@@ -193,6 +202,10 @@ static NSString *const kCellReuseIdentifier = @"cellReuseIdentifier";
 - (void)didChangeEmail:(NSString *)email andPassword:(NSString *)password {
   BOOL enableActionButton = email.length > 0 && password.length > 0;
   self.navigationItem.rightBarButtonItem.enabled = enableActionButton;
+}
+
+- (void)setOnDismissCallback:(FIRAuthDataResultCallback)callback {
+  _onDismissCallback = callback;
 }
 
 #pragma mark - UITableViewDataSource

--- a/FirebaseAuthUI/FUIPasswordSignInViewController.m
+++ b/FirebaseAuthUI/FUIPasswordSignInViewController.m
@@ -59,11 +59,6 @@ static NSString *const kCellReuseIdentifier = @"cellReuseIdentifier";
       @brief The @c UIButton which handles forgot password action.
    */
   __weak IBOutlet UIButton *_forgotPasswordButton;
-
-  /** @var _onDismissCallback
-      @brief The callback to be executed during view controller dismissal.
-   */
-  FIRAuthDataResultCallback _onDismissCallback;
 }
 
 - (instancetype)initWithAuthUI:(FUIAuth *)authUI
@@ -83,8 +78,12 @@ static NSString *const kCellReuseIdentifier = @"cellReuseIdentifier";
                          authUI:authUI];
   if (self) {
     _email = [email copy];
-    _onDismissCallback = nil;
+
     self.title = FUILocalizedString(kStr_SignInTitle);
+    __weak FUIPasswordSignInViewController *weakself = self;
+    _onDismissCallback = ^(FIRAuthDataResult *authResult, NSError *error){
+      [weakself.authUI invokeResultCallbackWithAuthDataResult:authResult error:error];
+    };
   }
   return self;
 }
@@ -141,8 +140,6 @@ static NSString *const kCellReuseIdentifier = @"cellReuseIdentifier";
       [self.navigationController dismissViewControllerAnimated:YES completion:^{
         if (self->_onDismissCallback) {
           self->_onDismissCallback(authResult, error);
-        } else {
-          [self.authUI invokeResultCallbackWithAuthDataResult:authResult error:error];
         }
       }];
     };
@@ -202,10 +199,6 @@ static NSString *const kCellReuseIdentifier = @"cellReuseIdentifier";
 - (void)didChangeEmail:(NSString *)email andPassword:(NSString *)password {
   BOOL enableActionButton = email.length > 0 && password.length > 0;
   self.navigationItem.rightBarButtonItem.enabled = enableActionButton;
-}
-
-- (void)setOnDismissCallback:(FIRAuthDataResultCallback)callback {
-  _onDismissCallback = callback;
 }
 
 #pragma mark - UITableViewDataSource

--- a/FirebaseAuthUI/FUIPasswordSignInViewController_Internal.h
+++ b/FirebaseAuthUI/FUIPasswordSignInViewController_Internal.h
@@ -21,13 +21,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface FUIPasswordSignInViewController ()
 
-/** @fn setOnDismissCallback:
+/** @property onDismissCallback:
     @brief Sets an optional custom callback for FUIPasswordSigInViewController during dismissal. If
-        this callback is set the default dismissal routine is not triggered and should be included
-        in this block if necessary.
-    @param callback The custom callback to execute during dismissal of the view controller.
+        this property is set the default dismissal routine is not triggered and should be included
+        in this block if necessary. This block is NOT set to nil after use, set to nil after using
+        if you wish to avoid circular references.
  */
-- (void)setOnDismissCallback:(FIRAuthDataResultCallback)callback;
+@property(nonatomic, strong, nullable) FIRAuthDataResultCallback onDismissCallback;
 
 NS_ASSUME_NONNULL_END
 

--- a/FirebaseAuthUI/FUIPasswordSignInViewController_Internal.h
+++ b/FirebaseAuthUI/FUIPasswordSignInViewController_Internal.h
@@ -1,0 +1,35 @@
+//
+//  Copyright (c) 2018 Google Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "FUIPasswordSignInViewController.h"
+#import <FirebaseAuth/FirebaseAuth.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FUIPasswordSignInViewController ()
+
+/** @fn setOnDismissCallback:
+    @brief Sets an optional custom callback for FUIPasswordSigInViewController during dismissal. If
+        this callback is set the default dismissal routine is not triggered and should be included
+        in this block if necessary.
+    @param callback The custom callback to execute during dismissal of the view controller.
+ */
+- (void)setOnDismissCallback:(FIRAuthDataResultCallback)callback;
+
+NS_ASSUME_NONNULL_END
+
+
+@end


### PR DESCRIPTION
Adds flow to sign into an existing email/password user (on a separate auth instance)  before linking this user to the federated auth credential during a merge conflict while upgrading anonymous user.
