### PR TITLE
Handles email mismatch case

### DIFF
--- a/FirebaseAuthUI/FUIAuth.m
+++ b/FirebaseAuthUI/FUIAuth.m
@@ -32,7 +32,7 @@
 #import "FUIPasswordVerificationViewController.h"
 
 /** @typedef EmailHintSignInCallback
-    @brief The type of block invoked when an emailHint sing-in event completes.
+    @brief The type of block invoked when an emailHint sign-in event completes.
 
     @param authResult Optionally; Result of sign-in request containing both the user and
        the additional user info associated with the user.

--- a/FirebaseAuthUI/FUIAuth.m
+++ b/FirebaseAuthUI/FUIAuth.m
@@ -399,7 +399,7 @@ static NSString *const kFirebaseAuthUIFrameworkMarker = @"FirebaseUI-iOS";
               if (![emailHint isEqualToString:authResult.user.email]) {
                 NSString *signedInEmail = authResult.user.email;
                 NSString *title =
-                    [NSString stringWithFormat:@"Continue sign in with %@", signedInEmail];
+                    [NSString stringWithFormat:@"Continue sign in with %@?", signedInEmail];
                 NSString *message =
                     [NSString stringWithFormat:@"You originally wanted to sign in with %@",
                     emailHint];
@@ -408,10 +408,14 @@ static NSString *const kFirebaseAuthUIFrameworkMarker = @"FirebaseUI-iOS";
                                                   actionTitle:@"Continue"
                                      presentingViewController:presentingViewController
                                                 actionHandler:^{
-                  completion(authResult, nil, credential);
+                  if (completion) {
+                    completion(authResult, nil, credential);
+                  }
                 }
                                                 cancelHandler:^{
-                  completion(nil, error, credential);
+                  if (completion) {
+                    completion(nil, error, credential);
+                  }
                 }];
               }
             }];

--- a/FirebaseAuthUI/FUIAuthBaseViewController.m
+++ b/FirebaseAuthUI/FUIAuthBaseViewController.m
@@ -242,6 +242,33 @@ static NSString *const kAuthUICodingKey = @"authUI";
   [presentingViewController presentViewController:alertController animated:YES completion:nil];
 }
 
++ (void)showAlertWithTitle:(nullable NSString *)title
+                   message:(NSString *)message
+               actionTitle:(NSString *)actionTitle
+  presentingViewController:(UIViewController *)presentingViewController
+             actionHandler:(FUIAuthAlertActionHandler)actionHandler
+             cancelHandler:(FUIAuthAlertActionHandler)cancelHandler {
+  UIAlertController *alertController =
+      [UIAlertController alertControllerWithTitle:title
+                                          message:message
+                                   preferredStyle:UIAlertControllerStyleAlert];
+  UIAlertAction *okAction =
+      [UIAlertAction actionWithTitle:actionTitle
+                               style:UIAlertActionStyleDefault
+                             handler:^(UIAlertAction *_Nonnull action) {
+        actionHandler();
+      }];
+  [alertController addAction:okAction];
+  UIAlertAction *cancelAction =
+      [UIAlertAction actionWithTitle:FUILocalizedString(kStr_Cancel)
+                               style:UIAlertActionStyleCancel
+                               handler:^(UIAlertAction * _Nonnull action) {
+        cancelHandler();
+      }];
+  [alertController addAction:cancelAction];
+  [presentingViewController presentViewController:alertController animated:YES completion:nil];
+}
+
 + (void)showSignInAlertWithEmail:(NSString *)email
                         provider:(id<FUIAuthProvider>)provider
         presentingViewController:(UIViewController *)presentingViewController

--- a/FirebaseAuthUI/FUIAuthBaseViewController_Internal.h
+++ b/FirebaseAuthUI/FUIAuthBaseViewController_Internal.h
@@ -61,6 +61,23 @@ typedef void (^FUIAuthAlertActionHandler)(void);
                  actionTitle:(NSString *)actionTitle
     presentingViewController:(UIViewController *)presentingViewController;
 
+/** @fn showAlertWithTitle:message:actionTitle:presentingViewController:
+    @brief Displays an alert view with given title, message and action title  on top of the
+        specified view controller.
+    @param title The title of the alert.
+    @param message The message of the alert.
+    @param actionTitle The title of the action button.
+    @param actionHandler The block to execute if the action button is tapped.
+    @param cancelHandler The block to execute if the cancel button is tapped.
+    @param presentingViewController The controller which shows alert.
+ */
++ (void)showAlertWithTitle:(nullable NSString *)title
+                   message:(NSString *)message
+               actionTitle:(NSString *)actionTitle
+  presentingViewController:(UIViewController *)presentingViewController
+             actionHandler:(FUIAuthAlertActionHandler)actionHandler
+             cancelHandler:(FUIAuthAlertActionHandler)cancelHandler;
+
 /** @fn showSignInAlertWithEmail:provider:handler:
     @brief Displays an alert to conform with user whether she wants to proceed with the provider.
     @param email The email address to sign in with.


### PR DESCRIPTION
Handles the case of email mismatch when the developer is prompted to sign-in with an existing account.

Does not include localization for new UI messages. These will be added in a separate PR.