### PR TITLE
Fix a bug where translation string is not correctly populated

### DIFF
--- a/FirebasePhoneAuthUI/FUIPrivacyAndTermsOfServiceView+PhoneAuth.m
+++ b/FirebasePhoneAuthUI/FUIPrivacyAndTermsOfServiceView+PhoneAuth.m
@@ -34,7 +34,7 @@
 - (NSAttributedString *)fullPrivacyPolicyAndTOSMessageWithSMSRateInfo {
   NSString *messageFormat =
       [NSString stringWithFormat:FUIPhoneAuthLocalizedString(kPAStr_TermsSMS),
-          FUIPhoneAuthLocalizedString(kPAStr_Verify)];
+          FUIPhoneAuthLocalizedString(kPAStr_Verify), @"%@", @"%@"];
   return [self privacyPolicyAndTOSMessageFromFormat:messageFormat];
 
 


### PR DESCRIPTION
fix #484 