### PR TITLE
Add information about the sign in response.

### DIFF
--- a/FirebasePhoneAuthUI/README.md
+++ b/FirebasePhoneAuthUI/README.md
@@ -101,3 +101,11 @@ If you don't need to handle APNS yourself, than don't do steps 3, 4, 5.
 
 Please notice that you can use either APNS key OR APNS certificate.
 <br>One APNS Key can be used for all your iOS app from the same Apple Developer account.
+
+12\. (Optional) To receive the callback response after the user attempt to sign in.
+
+```swift
+func authUI(_ authUI: FUIAuth, didSignInWith authDataResult: AuthDataResult?, error: Error?) {
+    // Do something with the response 
+}
+```


### PR DESCRIPTION
I was not sure about how could be possible to get the information about the attempt of the user sign in. So, I remember that the documentation says to set the auth delegate's to the view controller, such as: `authUI?.delegate = self`.

So, in order to get the response of the attempt, I overwrote the delegate method 
```objective-c
- (void)authUI:(FUIAuth *)authUI
    didSignInWithAuthDataResult:(nullable FIRAuthDataResult *)authDataResult
                          error:(nullable NSError *)error;
```

I just wanted to make it more clear for other developers.