### PR TITLE
FacebookAppID must not have the prefix fb

### DIFF
--- a/samples/swift/FirebaseUI-demo-swift/Info.plist
+++ b/samples/swift/FirebaseUI-demo-swift/Info.plist
@@ -54,7 +54,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>FacebookAppID</key>
-	<string>fb{your-app-id}</string>
+	<string>{your-app-id}</string>
 	<key>FacebookDisplayName</key>
 	<string>{your-app-name}</string>
 	<key>LSApplicationQueriesSchemes</key>


### PR DESCRIPTION
Changed FacebookAppID key from `fb{your-app-id}` to `{your-app-id}`

Hey there! So you want to contribute to FirebaseUI? Before you file this pull request, follow these steps:

  * Read [the contribution guidelines](CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to mention the issue number here.  If not, go file an issue about this to make sure this is a desirable change.
  * If this is a new feature please co-ordinate with someone on [FirebaseUI-Android](https://github.com/firebase/firebaseui-android) to make sure that we can implement this on both platforms and maintain feature parity.
