### PR TITLE
Fixed dismissal/completion handling in email sign in controller

### DIFF
--- a/EmailAuth/FirebaseEmailAuthUI/FUIPasswordSignInViewController.m
+++ b/EmailAuth/FirebaseEmailAuthUI/FUIPasswordSignInViewController.m
@@ -168,10 +168,10 @@ static NSString *const kCellReuseIdentifier = @"cellReuseIdentifier";
             return;
         }
       }
-      [self.navigationController dismissViewControllerAnimated:YES completion:^{
-        if (self->_onDismissCallback) {
-          self->_onDismissCallback(authResult, error);
-        }
+      [self dismissNavigationControllerAnimated:true completion:^{
+          if (self->_onDismissCallback) {
+              self->_onDismissCallback(authResult, error);
+          }
       }];
     };
 

--- a/EmailAuth/FirebaseEmailAuthUI/FUIPasswordSignInViewController_Internal.h
+++ b/EmailAuth/FirebaseEmailAuthUI/FUIPasswordSignInViewController_Internal.h
@@ -22,9 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FUIPasswordSignInViewController ()
 
 /** @property onDismissCallback:
-    @brief Sets an optional custom callback for FUIPasswordSigInViewController during dismissal. If
-        this property is set the default dismissal routine is not triggered and should be included
-        in this block if necessary. This block is NOT set to nil after use, set to nil after using
+    @brief Sets an optional custom callback for FUIPasswordSigInViewController during dismissal. This block is NOT set to nil after use, set to nil after using
         if you wish to avoid circular references.
  */
 @property(nonatomic, strong, nullable) FIRAuthDataResultCallback onDismissCallback;


### PR DESCRIPTION
Fixed completion callback calling in ```FUIPasswordSignInViewController``` (now it behaves the same way as other controllers - e.g., ```FUIPasswordSignUpViewController```). Corrected description.

Fixed #514 

