### PR TITLE
FUIEmailAuth.m Crash Fix

### DIFF
--- a/EmailAuth/FirebaseEmailAuthUI/FUIEmailAuth.m
+++ b/EmailAuth/FirebaseEmailAuthUI/FUIEmailAuth.m
@@ -219,6 +219,7 @@ static NSString *const kEmailLinkSignInLinkingCredentialKey = @"FIRAuthEmailLink
   }
   if (!continueURLString) {
     [FUIAuthBaseViewController showAlertWithMessage:@"Invalid link! Missing continue URL."];
+    return NO;
   }
 
   // Retrieve url parameters from continueUrl


### PR DESCRIPTION
If continueURLString is nil, "[NSURLComponents componentsWithString:continueURLString]" will crash.
Return NO for this un-handleOpenURL case.