### PR TITLE
Deprecate FUITwitterAuth. They will be removed

### DIFF
--- a/TwitterAuth/FirebaseTwitterAuthUI/FUITwitterAuth.h
+++ b/TwitterAuth/FirebaseTwitterAuthUI/FUITwitterAuth.h
@@ -21,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /** @class FUITwitterAuth
     @brief AuthUI components for Twitter Sign In.
  */
+DEPRECATED_MSG_ATTRIBUTE("Please use FUIOAuth instead of FUITwitterAuth.")
 @interface FUITwitterAuth : NSObject <FUIAuthProvider>
 
 @end

--- a/TwitterAuth/FirebaseTwitterAuthUI/FUITwitterAuth.m
+++ b/TwitterAuth/FirebaseTwitterAuthUI/FUITwitterAuth.m
@@ -24,6 +24,9 @@
 #import "FUIAuthStrings.h"
 #import "FUIAuthUtils.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 /** @var kTableName
     @brief The name of the strings table to search for localized strings.
  */
@@ -158,3 +161,5 @@ static NSString *const kSignInWithTwitter = @"SignInWithTwitter";
 }
 
 @end
+
+#pragma clang diagnostic pop

--- a/TwitterAuth/FirebaseTwitterAuthUI/FirebaseTwitterAuthUI.h
+++ b/TwitterAuth/FirebaseTwitterAuthUI/FirebaseTwitterAuthUI.h
@@ -17,10 +17,12 @@
 #import <UIKit/UIKit.h>
 
 //! Project version number for FirebaseTwitterAuthUI.
-FOUNDATION_EXPORT double FirebaseTwitterAuthUIVersionNumber;
+FOUNDATION_EXPORT double FirebaseTwitterAuthUIVersionNumber
+    DEPRECATED_MSG_ATTRIBUTE("Please use OAuth instead of TwitterAuth.");
 
 //! Project version string for FirebaseTwitterAuthUI.
-FOUNDATION_EXPORT const unsigned char FirebaseTwitterAuthUIVersionString[];
+FOUNDATION_EXPORT const unsigned char FirebaseTwitterAuthUIVersionString[]
+    DEPRECATED_MSG_ATTRIBUTE("Please use OAuth instead of TwitterAuth.");
 
 #import "FUITwitterAuth.h"
 

--- a/samples/objc/FirebaseUI-demo-objc/Samples/Auth/FUIAuthViewController.m
+++ b/samples/objc/FirebaseUI-demo-objc/Samples/Auth/FUIAuthViewController.m
@@ -407,7 +407,10 @@ static NSString *const kFirebasePrivacyPolicy = @"https://firebase.google.com/su
                                      :[[FUIFacebookAuth alloc] init];
           break;
         case kIDPTwitter:
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
           provider = [[FUITwitterAuth alloc] init];
+#pragma clang diagnostic pop
           break;
         case kIDPPhone:
           provider = [[FUIPhoneAuth alloc] initWithAuthUI:[FUIAuth defaultAuthUI]];

--- a/samples/swift/Podfile.lock
+++ b/samples/swift/Podfile.lock
@@ -60,43 +60,43 @@ PODS:
     - FirebaseAuthInterop (~> 1.0)
     - FirebaseCore (~> 5.2)
     - GTMSessionFetcher/Core (~> 1.1)
-  - FirebaseUI (6.1.1):
-    - FirebaseUI/Anonymous (= 6.1.1)
-    - FirebaseUI/Auth (= 6.1.1)
-    - FirebaseUI/Database (= 6.1.1)
-    - FirebaseUI/Email (= 6.1.1)
-    - FirebaseUI/Facebook (= 6.1.1)
-    - FirebaseUI/Firestore (= 6.1.1)
-    - FirebaseUI/Google (= 6.1.1)
-    - FirebaseUI/OAuth (= 6.1.1)
-    - FirebaseUI/Phone (= 6.1.1)
-    - FirebaseUI/Storage (= 6.1.1)
-    - FirebaseUI/Twitter (= 6.1.1)
-  - FirebaseUI/Anonymous (6.1.1):
+  - FirebaseUI (6.2.1):
+    - FirebaseUI/Anonymous (= 6.2.1)
+    - FirebaseUI/Auth (= 6.2.1)
+    - FirebaseUI/Database (= 6.2.1)
+    - FirebaseUI/Email (= 6.2.1)
+    - FirebaseUI/Facebook (= 6.2.1)
+    - FirebaseUI/Firestore (= 6.2.1)
+    - FirebaseUI/Google (= 6.2.1)
+    - FirebaseUI/OAuth (= 6.2.1)
+    - FirebaseUI/Phone (= 6.2.1)
+    - FirebaseUI/Storage (= 6.2.1)
+    - FirebaseUI/Twitter (= 6.2.1)
+  - FirebaseUI/Anonymous (6.2.1):
     - FirebaseUI/Auth
-  - FirebaseUI/Auth (6.1.1):
-    - Firebase/Auth (~> 5.0)
+  - FirebaseUI/Auth (6.2.1):
+    - Firebase/Auth (~> 5.4)
     - GoogleUtilities/UserDefaults
-  - FirebaseUI/Database (6.1.1):
+  - FirebaseUI/Database (6.2.1):
     - Firebase/Database (~> 5.0)
-  - FirebaseUI/Email (6.1.1):
+  - FirebaseUI/Email (6.2.1):
     - FirebaseUI/Auth
-  - FirebaseUI/Facebook (6.1.1):
+  - FirebaseUI/Facebook (6.2.1):
     - FBSDKLoginKit (~> 4.35)
     - FirebaseUI/Auth
-  - FirebaseUI/Firestore (6.1.1):
+  - FirebaseUI/Firestore (6.2.1):
     - Firebase/Firestore
-  - FirebaseUI/Google (6.1.1):
+  - FirebaseUI/Google (6.2.1):
     - FirebaseUI/Auth
     - GoogleSignIn (~> 4.0)
-  - FirebaseUI/OAuth (6.1.1):
+  - FirebaseUI/OAuth (6.2.1):
     - FirebaseUI/Auth
-  - FirebaseUI/Phone (6.1.1):
+  - FirebaseUI/Phone (6.2.1):
     - FirebaseUI/Auth
-  - FirebaseUI/Storage (6.1.1):
+  - FirebaseUI/Storage (6.2.1):
     - Firebase/Storage (~> 5.0)
     - SDWebImage (~> 4.0)
-  - FirebaseUI/Twitter (6.1.1):
+  - FirebaseUI/Twitter (6.2.1):
     - FirebaseUI/Auth
     - TwitterKit (~> 3.0)
   - GoogleSignIn (4.4.0):
@@ -192,7 +192,7 @@ SPEC CHECKSUMS:
   FirebaseDatabase: 23acb0c53cd4d4070a427b60100b2e4aaa97c45d
   FirebaseFirestore: ccdaffb8a73c591ff61872b8f7905ad0c237ef50
   FirebaseStorage: 29075f874c2b3cf61e5221a62c4ceefc809e5412
-  FirebaseUI: fc3584df29e96959d895677274681939fa30dbe5
+  FirebaseUI: 68cf8bcb7b770c397f13379657268e4193b300d6
   GoogleSignIn: 7ff245e1a7b26d379099d3243a562f5747e23d39
   GoogleToolboxForMac: ff31605b7d66400dcec09bed5861689aebadda4d
   GoogleUtilities: fa768ad04b264be250ee9edf9f378ad006f7a560


### PR DESCRIPTION
DO_NOT_SUBMIT

We need to do some changes to firebase sdk first to add twitter secret into the OAuthCredential. 

code to completely remove FUITwitterAuth is in https://github.com/firebase/FirebaseUI-iOS/pull/650