### PR TITLE
FirebaseUI/Facebook Update Version

### DIFF
--- a/FacebookAuth/Podfile
+++ b/FacebookAuth/Podfile
@@ -8,8 +8,8 @@ target 'FirebaseFacebookAuthUI' do
 
   # These are pinned to 4.35.0 to work around this bug:
   # https://developers.facebook.com/support/bugs/242258916492125/?disable_redirect=0
-  pod 'FBSDKLoginKit', '= 4.35.0'
-  pod 'FBSDKCoreKit', '= 4.35.0'
+  pod 'FBSDKLoginKit', '= 5.0.0'
+  pod 'FBSDKCoreKit', '= 5.0.0'
 
   pod 'FirebaseUI/Auth', :path => '../'
 


### PR DESCRIPTION
The following line:
pod 'FirebaseUI/Facebook'

Installs incompatible FBSDK Versions.
Installing FBSDKCoreKit (5.0.0)
Installing FBSDKLoginKit (4.44.1)

Hey there! So you want to contribute to FirebaseUI? Before you file this pull request, follow these steps:

  * Read [the contribution guidelines](CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to mention the issue number here.  If not, go file an issue about this to make sure this is a desirable change.
  * If this is a new feature please co-ordinate with someone on [FirebaseUI-Android](https://github.com/firebase/firebaseui-android) to make sure that we can implement this on both platforms and maintain feature parity.
