### PR TITLE
Fix requireDisplayname handling

### DIFF
--- a/EmailAuth/FirebaseEmailAuthUI/FUIPasswordSignUpViewController.m
+++ b/EmailAuth/FirebaseEmailAuthUI/FUIPasswordSignUpViewController.m
@@ -283,17 +283,32 @@ static const CGFloat kTextFieldRightViewSize = 36.0f;
       _emailField.textContentType = UITextContentTypeUsername;
     }
   } else if (indexPath.row == 1) {
-    cell.label.text = FUILocalizedString(kStr_Name);
-    cell.accessibilityIdentifier = kNameSignUpCellAccessibilityID;
-    _nameField = cell.textField;
-    _nameField.placeholder = FUILocalizedString(kStr_FirstAndLastName);
-    _nameField.secureTextEntry = NO;
-    _nameField.returnKeyType = UIReturnKeyNext;
-    _nameField.keyboardType = UIKeyboardTypeDefault;
-    _nameField.autocapitalizationType = UITextAutocapitalizationTypeWords;
-    if (@available(iOS 10.0, *)) {
-      _nameField.textContentType = UITextContentTypeName;
-    }
+      if (_requireDisplayName) {
+          cell.label.text = FUILocalizedString(kStr_Name);
+          cell.accessibilityIdentifier = kNameSignUpCellAccessibilityID;
+          _nameField = cell.textField;
+          _nameField.placeholder = FUILocalizedString(kStr_FirstAndLastName);
+          _nameField.secureTextEntry = NO;
+          _nameField.returnKeyType = UIReturnKeyNext;
+          _nameField.keyboardType = UIKeyboardTypeDefault;
+          _nameField.autocapitalizationType = UITextAutocapitalizationTypeWords;
+          if (@available(iOS 10.0, *)) {
+              _nameField.textContentType = UITextContentTypeName;
+          }
+      } else {
+          cell.label.text = FUILocalizedString(kStr_Password);
+          cell.accessibilityIdentifier = kPasswordSignUpCellAccessibilityID;
+          _passwordField = cell.textField;
+          _passwordField.placeholder = FUILocalizedString(kStr_ChoosePassword);
+          _passwordField.secureTextEntry = YES;
+          _passwordField.rightView = [self visibilityToggleButtonForPasswordField];
+          _passwordField.rightViewMode = UITextFieldViewModeAlways;
+          _passwordField.returnKeyType = UIReturnKeyNext;
+          _passwordField.keyboardType = UIKeyboardTypeDefault;
+          if (@available(iOS 11.0, *)) {
+              _passwordField.textContentType = UITextContentTypePassword;
+          }
+      }
   } else if (indexPath.row == 2) {
     cell.label.text = FUILocalizedString(kStr_Password);
     cell.accessibilityIdentifier = kPasswordSignUpCellAccessibilityID;
@@ -306,18 +321,6 @@ static const CGFloat kTextFieldRightViewSize = 36.0f;
     _passwordField.keyboardType = UIKeyboardTypeDefault;
     if (@available(iOS 11.0, *)) {
       _passwordField.textContentType = UITextContentTypePassword;
-    }
-  } else if (indexPath.row == 2) {
-    cell.label.text = FUILocalizedString(kStr_Name);
-    cell.accessibilityIdentifier = kNameSignUpCellAccessibilityID;
-    _nameField = cell.textField;
-    _nameField.placeholder = FUILocalizedString(kStr_FirstAndLastName);
-    _nameField.secureTextEntry = NO;
-    _nameField.returnKeyType = UIReturnKeyNext;
-    _nameField.keyboardType = UIKeyboardTypeDefault;
-    _nameField.autocapitalizationType = UITextAutocapitalizationTypeWords;
-    if (@available(iOS 10.0, *)) {
-      _nameField.textContentType = UITextContentTypeName;
     }
   }
   [cell.textField addTarget:self


### PR DESCRIPTION
# Problems

```
func passwordSignUpViewController(forAuthUI authUI: FUIAuth, email: String, requireDisplayName: Bool) -> FUIPasswordSignUpViewController {
    return FUIPasswordSignUpViewController(authUI: authUI, email: email, requireDisplayName: false)
}
```

<img width="598" alt="スクリーンショット 2019-06-13 16 20 18" src="https://user-images.githubusercontent.com/13015492/59420589-1bdf1c80-8e08-11e9-8007-42f863e162d4.png">
