### PR TITLE
Readme improvements

### DIFF
--- a/Auth/README.md
+++ b/Auth/README.md
@@ -361,6 +361,11 @@ Refer to the Objective-C and Swift samples for examples of how you can customize
 these views.
 
 ## Handling auto-upgrade of anonymous users
+By default, the auto-upgrade of anonymous users is disabled. You can enable it 
+by simply changing the associated attribute of your Firebase Auth instance:
+```swift
+authUI?.shouldAutoUpgradeAnonymousUsers = true
+```
 
 Enabling auto-upgrade of anonymous users increases the complexity of your auth
 flow by adding several more edge cases that need to be handled. As opposed to

--- a/Auth/README.md
+++ b/Auth/README.md
@@ -213,7 +213,7 @@ Auth.defaultAuthUI.handleOpenURL(url, sourceApplication: sourceApplication)
 We support cross device email link sign in for the normal flows. It is not supported with anonymous user upgrade. By default, cross device support is enabled. You can disable it setting `forceSameDevice` to false in the `FUIEmailAuth` initializer.
 
 ## Customizing FirebaseUI for authentication
-### Custom terms of Service (ToS) URL
+### Custom Terms of Service (ToS) and privacy policy URLs
 
 The Terms of Service URL for your application, which is displayed on the
 email/password account creation screen, can be specified as follows:
@@ -227,6 +227,13 @@ authUI?.tosurl = kFirebaseTermsOfService
 ```objective-c
 // Objective-C
 authUI.TOSURL = [NSURL URLWithString:@"https://example.com/tos"];
+```
+
+The same applies to the URL of your privacy policy:
+```swift
+// Swift
+let kFirebasePrivacyPolicy = URL(string: "https://policies.google.com/privacy")!
+authUI?.privacyPolicyURL = kFirebasePrivacyPolicy
 ```
 
 ### Custom strings


### PR DESCRIPTION
Some improvements for the readme file of Firebase Auth:

1:
It took me quite a long time to figure out that I need to enable the auto-upgrade of users manually. As far as I know, it's not mentioned anywhere in the docs.

2:
Not as important as the first point, but the docs could mention the privacy policy url just as they already do for the ToS.

(I've not added any Objective-C code snippets, because I've never used Objective-C yet. Should be very easy to add though.)