### PR TITLE
Addressing issue #464

### DIFF
--- a/EmailAuth/FirebaseEmailAuthUI/FUIPasswordSignInViewController.m
+++ b/EmailAuth/FirebaseEmailAuthUI/FUIPasswordSignInViewController.m
@@ -249,6 +249,7 @@ static NSString *const kCellReuseIdentifier = @"cellReuseIdentifier";
   cell.textField.delegate = self;
   if (indexPath.row == 0) {
     cell.label.text = FUILocalizedString(kStr_Email);
+    cell.textField.enabled = NO;
     _emailField = cell.textField;
     _emailField.text = _email;
     _emailField.placeholder = FUILocalizedString(kStr_EnterYourEmail);

--- a/EmailAuth/FirebaseEmailAuthUI/FUIPasswordSignUpViewController.m
+++ b/EmailAuth/FirebaseEmailAuthUI/FUIPasswordSignUpViewController.m
@@ -271,6 +271,7 @@ static const CGFloat kTextFieldRightViewSize = 36.0f;
   if (indexPath.row == 0) {
     cell.label.text = FUILocalizedString(kStr_Email);
     cell.accessibilityIdentifier = kEmailSignUpCellAccessibilityID;
+    cell.textField.enabled = NO;
     _emailField = cell.textField;
     _emailField.text = _email;
     _emailField.placeholder = FUILocalizedString(kStr_EnterYourEmail);


### PR DESCRIPTION
Regarding the comments from the original ticket (https://github.com/firebase/FirebaseUI-iOS/issues/464) :

- Always displaying the `displayName field` hasn't been implemented as a custom field `_requireDisplayName` has been created specifically for this and should be used by the developer. 
- The email address field on the sign-in and sign-up controllers have been disabled from editing for the following reason: 
    - the email address is being verified in the previous screen and allowing the user to edit it at this point bypasses all the previous validations (so the user can potentially signup with an existing email address for example). I tested all cases and it does throw an error message properly handled every time but it still feels like a bug and potentially opens the door to other issue for future development. The back button provides a mean to modify the email address **with** all required validations

Let me know if that makes sense or if you'd like to see any other change applied and I'll update the PR