### PR TITLE
Update StorageUI integration with SDWebImage

### DIFF
--- a/FirebaseUI.podspec
+++ b/FirebaseUI.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
     storage.public_header_files = 'Storage/FirebaseStorageUI/*.h'
     storage.source_files = 'Storage/FirebaseStorageUI/*.{h,m}'
     storage.dependency 'Firebase/Storage', '~> 6.0'
-    storage.dependency 'SDWebImage', '~> 5.0'
+    storage.dependency 'SDWebImage', '~> 5.6'
     storage.xcconfig = { 'HEADER_SEARCH_PATHS' => '$(PODS_ROOT)/FirebaseUI/FirebaseStorageUI' }
   end
 

--- a/Storage/FirebaseStorageUI/FUIStorageImageLoader.m
+++ b/Storage/FirebaseStorageUI/FUIStorageImageLoader.m
@@ -17,10 +17,17 @@
 #import "FUIStorageImageLoader.h"
 #import "FIRStorageDownloadTask+SDWebImage.h"
 #import <FirebaseCore/FirebaseCore.h>
+#import <GTMSessionFetcher/GTMSessionFetcher.h>
 
 @interface NSURL ()
 
 @property (nonatomic, strong, readwrite, nullable) FIRStorageReference *sd_storageReference;
+
+@end
+
+@interface FIRStorageTask ()
+
+@property(strong, atomic) GTMSessionFetcher *fetcher;
 
 @end
 
@@ -79,7 +86,6 @@
   }
   // Download the image from Firebase Storage
   
-  // TODO: Support progressive image loading using the `GTMSessionFetcher.downloadedData` with `SDImageLoaderDecodeProgressiveImageData`
   FIRStorageDownloadTask * download = [storageRef dataWithMaxSize:size
                                                        completion:^(NSData * _Nullable data, NSError * _Nullable error) {
                                                          if (error) {
@@ -102,6 +108,24 @@
                                                        }];
   // Observe the progress changes
   [download observeStatus:FIRStorageTaskStatusProgress handler:^(FIRStorageTaskSnapshot * _Nonnull snapshot) {
+    // Check progressive decoding if need
+    if (options & SDWebImageProgressiveLoad) {
+      FIRStorageDownloadTask *task = snapshot.task;
+      // Currently, FIRStorageDownloadTask does not have the API to grab partial data
+      // But since FirebaseUI and Firebase are seamless component, we access the internal fetcher here
+      GTMSessionFetcher *fetcher = task.fetcher;
+      // Get the partial image data
+      NSData *partialData = [fetcher.downloadedData copy];
+      // Get the finish status
+      BOOL finished = (fetcher.downloadedLength >= fetcher.bodyLength);
+      // This progress block is callbacked on global queue, so it's OK to decode
+      UIImage *image = SDImageLoaderDecodeProgressiveImageData(partialData, url, finished, download, options, context);
+      if (image) {
+        if (completedBlock) {
+          completedBlock(image, partialData, nil, NO);
+        }
+      }
+    }
     NSProgress *progress = snapshot.progress;
     if (progressBlock) {
       progressBlock((NSInteger)progress.completedUnitCount,

--- a/Storage/FirebaseStorageUI/FUIStorageImageLoader.m
+++ b/Storage/FirebaseStorageUI/FUIStorageImageLoader.m
@@ -119,11 +119,13 @@
       // Get the finish status
       BOOL finished = (fetcher.downloadedLength >= fetcher.bodyLength);
       // This progress block is callbacked on global queue, so it's OK to decode
-      UIImage *image = SDImageLoaderDecodeProgressiveImageData(partialData, url, finished, download, options, context);
+      UIImage *image = SDImageLoaderDecodeProgressiveImageData(partialData, url, finished, task, options, context);
       if (image) {
-        if (completedBlock) {
-          completedBlock(image, partialData, nil, NO);
-        }
+        dispatch_main_async_safe(^{
+          if (completedBlock) {
+            completedBlock(image, partialData, nil, NO);
+          }
+        });
       }
     }
     NSProgress *progress = snapshot.progress;

--- a/Storage/FirebaseStorageUI/UIImageView+FirebaseStorage.m
+++ b/Storage/FirebaseStorageUI/UIImageView+FirebaseStorage.m
@@ -17,15 +17,6 @@
 #import "UIImageView+FirebaseStorage.h"
 #import "FUIStorageImageLoader.h"
 
-static SDWebImageManager *DefaultWebImageManager(void) {
-  static dispatch_once_t onceToken;
-  static SDWebImageManager *manager;
-  dispatch_once(&onceToken, ^{
-    manager = [[SDWebImageManager alloc] initWithCache:SDImageCache.sharedImageCache loader:FUIStorageImageLoader.sharedLoader];
-  });
-  return manager;
-}
-
 @implementation UIImageView (FirebaseStorage)
 
 - (void)sd_setImageWithStorageReference:(FIRStorageReference *)storageRef {
@@ -121,12 +112,8 @@ static SDWebImageManager *DefaultWebImageManager(void) {
   } else {
     mutableContext = [NSMutableDictionary dictionary];
   }
-  if (!mutableContext[SDWebImageContextCustomManager]) {
-    mutableContext[SDWebImageContextCustomManager] = DefaultWebImageManager();
-  }
-  if (!mutableContext[SDWebImageContextFUIStorageMaxImageSize]) {
-    mutableContext[SDWebImageContextFUIStorageMaxImageSize] = @(size);
-  }
+  mutableContext[SDWebImageContextImageLoader] = FUIStorageImageLoader.sharedLoader;
+  mutableContext[SDWebImageContextFUIStorageMaxImageSize] = @(size);
   
   [self sd_setImageWithURL:url placeholderImage:placeholder options:options context:[mutableContext copy] progress:^(NSInteger receivedSize, NSInteger expectedSize, NSURL * _Nullable targetURL) {
     if (progressBlock) {

--- a/Storage/Podfile.lock
+++ b/Storage/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - Firebase/CoreOnly (6.15.0):
-    - FirebaseCore (= 6.6.0)
-  - Firebase/Storage (6.15.0):
+  - Firebase/CoreOnly (6.18.0):
+    - FirebaseCore (= 6.6.3)
+  - Firebase/Storage (6.18.0):
     - Firebase/CoreOnly
     - FirebaseStorage (~> 3.5.0)
   - FirebaseAuthInterop (1.0.0)
-  - FirebaseCore (6.6.0):
+  - FirebaseCore (6.6.3):
     - FirebaseCoreDiagnostics (~> 1.2)
     - FirebaseCoreDiagnosticsInterop (~> 1.2)
     - GoogleUtilities/Environment (~> 6.5)
     - GoogleUtilities/Logger (~> 6.5)
-  - FirebaseCoreDiagnostics (1.2.0):
+  - FirebaseCoreDiagnostics (1.2.1):
     - FirebaseCoreDiagnosticsInterop (~> 1.2)
     - GoogleDataTransportCCTSupport (~> 1.3)
     - GoogleUtilities/Environment (~> 6.5)
@@ -21,12 +21,12 @@ PODS:
     - FirebaseAuthInterop (~> 1.0)
     - FirebaseCore (~> 6.0)
     - GTMSessionFetcher/Core (~> 1.1)
-  - GoogleDataTransport (3.3.0)
-  - GoogleDataTransportCCTSupport (1.3.0):
-    - GoogleDataTransport (~> 3.3)
+  - GoogleDataTransport (4.0.1)
+  - GoogleDataTransportCCTSupport (1.4.1):
+    - GoogleDataTransport (~> 4.0)
     - nanopb (~> 0.3.901)
-  - GoogleUtilities/Environment (6.5.0)
-  - GoogleUtilities/Logger (6.5.0):
+  - GoogleUtilities/Environment (6.5.1)
+  - GoogleUtilities/Logger (6.5.1):
     - GoogleUtilities/Environment
   - GTMSessionFetcher/Core (1.3.1)
   - nanopb (0.3.9011):
@@ -34,10 +34,10 @@ PODS:
     - nanopb/encode (= 0.3.9011)
   - nanopb/decode (0.3.9011)
   - nanopb/encode (0.3.9011)
-  - OCMock (3.5)
-  - SDWebImage (5.5.1):
-    - SDWebImage/Core (= 5.5.1)
-  - SDWebImage/Core (5.5.1)
+  - OCMock (3.6)
+  - SDWebImage (5.6.0):
+    - SDWebImage/Core (= 5.6.0)
+  - SDWebImage/Core (5.6.0)
 
 DEPENDENCIES:
   - Firebase/Storage
@@ -61,19 +61,19 @@ SPEC REPOS:
     - SDWebImage
 
 SPEC CHECKSUMS:
-  Firebase: 5d77105d9740a07ca6b16927ca971db7e860faaf
+  Firebase: 0490eca762a72e4f1582319539153897f1508dee
   FirebaseAuthInterop: 0ffa57668be100582bb7643d4fcb7615496c41fc
-  FirebaseCore: 4aeb81ff53dcd9a3634ca725dc1fb8c2a4622046
-  FirebaseCoreDiagnostics: 5e78803ab276bc5b50340e3c539c06c3de35c649
+  FirebaseCore: 78276943ad85e616dfa54dafa6c89512987d9d60
+  FirebaseCoreDiagnostics: 2109d10c35e8289b1ee6cabf44d9ffb055620194
   FirebaseCoreDiagnosticsInterop: 296e2c5f5314500a850ad0b83e9e7c10b011a850
   FirebaseStorage: 6c5263796af3b1be82ed173598aade47535fe125
-  GoogleDataTransport: 574a983e829327d7c18f2627f65d9e80164ea8a4
-  GoogleDataTransportCCTSupport: cad3cd6cdbdbad6b5c2c9206ec413402755faaaa
-  GoogleUtilities: f8de7ddf8c706f58e9b405d53e38bbdaa2731e5a
+  GoogleDataTransport: 653963cf5be60fb59cf051e070f0836fdc305f81
+  GoogleDataTransportCCTSupport: 84e4d4bbab642f2e9d83ee65d78aca2b5527d314
+  GoogleUtilities: 06eb53bb579efe7099152735900dd04bf09e7275
   GTMSessionFetcher: cea130bbfe5a7edc8d06d3f0d17288c32ffe9925
   nanopb: 18003b5e52dab79db540fe93fe9579f399bd1ccd
-  OCMock: 4ab4577fc941af31f4a0398f6e7e230cf21fc72a
-  SDWebImage: 1245d058b7b8f59adef7a6da6bbafd4f1ab67041
+  OCMock: 5ea90566be239f179ba766fd9fbae5885040b992
+  SDWebImage: 21b19f56b4226cdfe3aefe4e6848dc43ed129a86
 
 PODFILE CHECKSUM: 4ee09a538f9ded78a1ee0184c63b1157301e92e4
 

--- a/Storage/README.md
+++ b/Storage/README.md
@@ -25,19 +25,27 @@ UIImageView *imageView = ...;
 
 // Load the image using SDWebImage
 [imageView sd_setImageWithStorageReference:reference placeholderImage:placeholderImage];
+
+// You can also use gs:// URL directly with StorageImageLoader
+NSURL *storageUrl = [NSURL URLWithString:@"gs://..."];
+[imageView sd_setImageWithURL:storageUrl placeholderImage:placeholderImage options:0 context:@{SDWebImageContextImageLoader : FUIStorageImageLoader.sharedLoader}];
 ```
 
 ```swift
 // Swift
 
 // Reference to an image file in Cloud Storage
-let reference: StorageReference = ...;
+let reference: StorageReference = ...
 
 // UIImageView in your ViewController
-let imageView: UIImageView = ...;
+let imageView: UIImageView = ...
 
 // Load the image using SDWebImage
-imageView.sd_setImageWithStorageReference(reference, placeholderImage: placeholderImage)
+imageView.sd_setImage(with: reference, placeholderImage: placeholderImage)
+
+// You can also use gs:// URL directly with StorageImageLoader
+let storageUrl = URL(string: "gs://...")
+imageView.sd_setImage(with: storageUrl, placeholderImage: placeholderImage, options:[], context: [.imageLoader : StorageImageLoader.shared])
 ```
 
 Images are cached by their path in Cloud Storage, so repeated loads will be

--- a/Storage/README.md
+++ b/Storage/README.md
@@ -26,9 +26,12 @@ UIImageView *imageView = ...;
 // Load the image using SDWebImage
 [imageView sd_setImageWithStorageReference:reference placeholderImage:placeholderImage];
 
-// You can also use gs:// URL directly with StorageImageLoader
+// Use gs:// URL directly with StorageImageLoader
 NSURL *storageUrl = [NSURL URLWithString:@"gs://..."];
 [imageView sd_setImageWithURL:storageUrl placeholderImage:placeholderImage options:0 context:@{SDWebImageContextImageLoader : FUIStorageImageLoader.sharedLoader}];
+
+// Use progressive downloading and decoding for images
+[imageView sd_setImageWithStorageReference:reference placeholderImage:placeholderImage options:SDWebImageProgressiveLoad];
 ```
 
 ```swift
@@ -43,9 +46,12 @@ let imageView: UIImageView = ...
 // Load the image using SDWebImage
 imageView.sd_setImage(with: reference, placeholderImage: placeholderImage)
 
-// You can also use gs:// URL directly with StorageImageLoader
+// Use gs:// URL directly with StorageImageLoader
 let storageUrl = URL(string: "gs://...")
 imageView.sd_setImage(with: storageUrl, placeholderImage: placeholderImage, options:[], context: [.imageLoader : StorageImageLoader.shared])
+
+// Use progressive downloading and decoding for images
+imageView.sd_setImage(with: reference, placeholderImage: placeholderImage, options: [.progressiveLoad])
 ```
 
 Images are cached by their path in Cloud Storage, so repeated loads will be


### PR DESCRIPTION
Hey there! So you want to contribute to FirebaseUI? Before you file this pull request, follow these steps:

  * Read [the contribution guidelines](CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to mention the issue number here.  If not, go file an issue about this to make sure this is a desirable change.
  * If this is a new feature please co-ordinate with someone on [FirebaseUI-Android](https://github.com/firebase/firebaseui-android) to make sure that we can implement this on both platforms and maintain feature parity.

This PR add the following features:

1. Use [SDWebImage 5.6.0](https://github.com/SDWebImage/SDWebImage/releases/tag/5.6.0) 's loader context option, instead of dummy manager instance. This is easier to use. And can avoid user who overrde the default manager's property (like transformer), which cause the undefined behavior when using with FirebaseUI Storage
2. Add the support to load `gs://` URl directly, not always need to create a wrapper `FIRStorageReference`.
3. Add the support to progressive downloading and decoding of images, this can be the use case who want to load partial images and display for users.

The dependency of SDWebImage bumped to 5.6.0, beucase of the PR feature 1 need the new API.

CC @morganchen12