### PR TITLE
Fix StorageUI Bug and Update demo usage for SDWebImgae integration

### DIFF
--- a/samples/objc/FirebaseUI-demo-objc/Samples/Storage/FUIStorageViewController.m
+++ b/samples/objc/FirebaseUI-demo-objc/Samples/Storage/FUIStorageViewController.m
@@ -37,6 +37,10 @@
   self.imageView.contentMode = UIViewContentModeScaleAspectFit;
   self.textField.autocapitalizationType = UITextAutocapitalizationTypeNone;
   self.textField.autocorrectionType = UITextAutocorrectionTypeNo;
+  self.navigationItem.rightBarButtonItem = [UIBarButtonItem.alloc initWithTitle:@"Clear Cache"
+                                                                          style:UIBarButtonItemStylePlain
+                                                                         target:self
+                                                                         action:@selector(flushCache)];
 }
 
 - (void)viewDidAppear:(BOOL)animated {
@@ -66,7 +70,9 @@
     referenceWithPath:url.path ?: @""];
 
   [self.imageView sd_setImageWithStorageReference:storageRef
+                                     maxImageSize:10e6
                                  placeholderImage:nil
+                                          options:SDWebImageProgressiveLoad
                                        completion:^(UIImage *image,
                                                     NSError *error,
                                                     SDImageCacheType
@@ -76,6 +82,11 @@
       NSLog(@"Error loading image: %@", error.localizedDescription);
     }
   }];
+}
+
+- (void)flushCache {
+    [SDImageCache.sharedImageCache clearMemory];
+    [SDImageCache.sharedImageCache clearDiskOnCompletion:nil];
 }
 
 #pragma mark - Keyboard boilerplate

--- a/samples/objc/FirebaseUI-demo-objc/Samples/Storage/FUIStorageViewController.m
+++ b/samples/objc/FirebaseUI-demo-objc/Samples/Storage/FUIStorageViewController.m
@@ -70,7 +70,7 @@
     referenceWithPath:url.path ?: @""];
 
   [self.imageView sd_setImageWithStorageReference:storageRef
-                                     maxImageSize:10e6
+                                     maxImageSize:10e7
                                  placeholderImage:nil
                                           options:SDWebImageProgressiveLoad
                                        completion:^(UIImage *image,

--- a/samples/swift/FirebaseUI-demo-swift/Samples/StorageViewController.swift
+++ b/samples/swift/FirebaseUI-demo-swift/Samples/StorageViewController.swift
@@ -63,7 +63,7 @@ class StorageViewController: UIViewController {
     }
   }
   
-  @objc fileprivate func flushCache() {
+  @objc private func flushCache() {
     SDImageCache.shared.clearMemory()
     SDImageCache.shared.clearDisk()
   }

--- a/samples/swift/FirebaseUI-demo-swift/Samples/StorageViewController.swift
+++ b/samples/swift/FirebaseUI-demo-swift/Samples/StorageViewController.swift
@@ -24,6 +24,10 @@ class StorageViewController: UIViewController {
   @IBOutlet fileprivate var textField: UITextField!
 
   fileprivate var storageRef = Storage.storage().reference()
+  
+  override func viewDidLoad() {
+    self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Clear Cache", style: .plain, target: self, action: #selector(flushCache))
+  }
 
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
@@ -50,11 +54,18 @@ class StorageViewController: UIViewController {
     self.storageRef = Storage.storage().reference(withPath: url.path)
 
     self.imageView.sd_setImage(with: self.storageRef,
-      placeholderImage: nil) { (image, error, cacheType, storageRef) in
+                               maxImageSize: 10000000,
+                               placeholderImage: nil,
+                               options: [.progressiveLoad]) { (image, error, cacheType, storageRef) in
       if let error = error {
         print("Error loading image: \(error)")
       }
     }
+  }
+  
+  @objc fileprivate func flushCache() {
+    SDImageCache.shared.clearMemory()
+    SDImageCache.shared.clearDisk()
   }
 
   // MARK: Keyboard boilerplate


### PR DESCRIPTION
Hey there! So you want to contribute to FirebaseUI? Before you file this pull request, follow these steps:

  * Read [the contribution guidelines](CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to mention the issue number here.  If not, go file an issue about this to make sure this is a desirable change.
  * If this is a new feature please co-ordinate with someone on [FirebaseUI-Android](https://github.com/firebase/firebaseui-android) to make sure that we can implement this on both platforms and maintain feature parity.

Fix issues related StorageUI and SDWebImage, introduced in #841 

 1. The FIRStorage throw exception on passed url contains object path
2. The progress block may been called on main queue, should use another coder queue for decoding
3. The expectedSize should use URLResponse's info to check, but not the bodyLength

CC @morganchen12 