### PR TITLE
Fix Apple IdentityToken conversion

### DIFF
--- a/OAuth/FirebaseOAuthUI/FUIOAuth.m
+++ b/OAuth/FirebaseOAuthUI/FUIOAuth.m
@@ -308,7 +308,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)authorizationController:(ASAuthorizationController *)controller didCompleteWithAuthorization:(ASAuthorization *)authorization API_AVAILABLE(ios(13.0)) {
   ASAuthorizationAppleIDCredential* appleIDCredential = authorization.credential;
-  NSString *idToken = [NSString stringWithUTF8String:[appleIDCredential.identityToken bytes]];
+  NSString *idToken = [[NSString alloc] initWithData:appleIDCredential.identityToken encoding:NSUTF8StringEncoding];
   FIROAuthCredential *credential = [FIROAuthProvider credentialWithProviderID:@"apple.com"
                                                                       IDToken:idToken
                                                                   accessToken:nil];


### PR DESCRIPTION
Fix for #880 and possibly #830 


My knowledge is limited for Objective-C so any feedback is welcomed. Solution taken from [stackoverflow](https://stackoverflow.com/questions/29005246/stringwithutf8string-returning-nil-since-ios-8-2-update)

