### PR TITLE
Fix Apple login button color to white when in dark mode

### DIFF
--- a/OAuth/FirebaseOAuthUI/FUIOAuth.m
+++ b/OAuth/FirebaseOAuthUI/FUIOAuth.m
@@ -195,7 +195,7 @@ NS_ASSUME_NONNULL_BEGIN
                             fromBundleNameOrNil:@"FirebaseOAuthUI"];
   UIColor *buttonColor = [UIColor blackColor];
   UIColor *buttonTextColor = [UIColor whiteColor];
-  if (UITraitCollection.currentTraitCollection.userInterfaceStyle == UIUserInterfaceStyleLight) {
+  if (UITraitCollection.currentTraitCollection.userInterfaceStyle == UIUserInterfaceStyleDark) {
     iconImage = [iconImage imageWithTintColor:[UIColor blackColor]];
     buttonColor = [UIColor whiteColor];
     buttonTextColor = [UIColor blackColor];


### PR DESCRIPTION
This PR fix the issue related Apple login button color, introduced in #841

We should set white button color when background is dark or colored.
https://developer.apple.com/design/human-interface-guidelines/sign-in-with-apple/overview/buttons/
![image](https://user-images.githubusercontent.com/11647461/95655631-be65f780-0b43-11eb-9931-a4dff483e3df.png)
 