### PR TITLE
Support setting custom UserInterfaceStyle for AppleAuth

### DIFF
--- a/OAuth/FirebaseOAuthUI/FUIOAuth.h
+++ b/OAuth/FirebaseOAuthUI/FUIOAuth.h
@@ -91,6 +91,11 @@ NS_ASSUME_NONNULL_BEGIN
 */
 + (FUIOAuth *)appleAuthProvider API_AVAILABLE(ios(13.0));
 
+/** @fn appleAuthProvider
+    @brief Built-in OAuth provider with custom UserInterfaceStyle for Apple.
+*/
++ (FUIOAuth *)appleAuthProviderWithUserInterfaceStyle:(UIUserInterfaceStyle)userInterfaceStyle API_AVAILABLE(ios(13.0));
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/OAuth/FirebaseOAuthUI/FUIOAuth.m
+++ b/OAuth/FirebaseOAuthUI/FUIOAuth.m
@@ -191,11 +191,15 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (FUIOAuth *)appleAuthProvider {
+  return [self appleAuthProviderWithUserInterfaceStyle:UITraitCollection.currentTraitCollection.userInterfaceStyle];
+}
+
++ (FUIOAuth *)appleAuthProviderWithUserInterfaceStyle:(UIUserInterfaceStyle)userInterfaceStyle {
   UIImage *iconImage = [FUIAuthUtils imageNamed:@"ic_apple"
                             fromBundleNameOrNil:@"FirebaseOAuthUI"];
   UIColor *buttonColor = [UIColor blackColor];
   UIColor *buttonTextColor = [UIColor whiteColor];
-  if (UITraitCollection.currentTraitCollection.userInterfaceStyle == UIUserInterfaceStyleDark) {
+  if (userInterfaceStyle == UIUserInterfaceStyleDark) {
     iconImage = [iconImage imageWithTintColor:[UIColor blackColor]];
     buttonColor = [UIColor whiteColor];
     buttonTextColor = [UIColor blackColor];


### PR DESCRIPTION
This PR is related with https://github.com/firebase/FirebaseUI-iOS/pull/907#issuecomment-711027069.
Depending on the situation, it is need to configure custom `UserInterfaceStyle`.
