### PR TITLE
Fixes override of nil default

### DIFF
--- a/EmailAuth/FirebaseEmailAuthUI/FUIEmailAuth.m
+++ b/EmailAuth/FirebaseEmailAuthUI/FUIEmailAuth.m
@@ -200,7 +200,7 @@ static NSString *const kEmailLinkSignInLinkingCredentialKey = @"FIRAuthEmailLink
   } else {
     if ([delegate respondsToSelector:@selector(passwordSignInViewControllerForAuthUI:email:)]) {
       controller = [delegate passwordSignInViewControllerForAuthUI:self.authUI
-                                                             email:defaultValue ?: @""];
+                                                             email:defaultValue];
     } else {
       controller = [[FUIPasswordSignInViewController alloc] initWithAuthUI:self.authUI
                                                                      email:defaultValue];


### PR DESCRIPTION
Fixes disabled eMail textfield if subclassing FUIPasswordSignInViewController, since that checks if email is nil
