### PR TITLE
Handle CLIENT_ID missing in Google Sign-In

### DIFF
--- a/GoogleAuth/FirebaseGoogleAuthUI/FUIGoogleAuth.m
+++ b/GoogleAuth/FirebaseGoogleAuthUI/FUIGoogleAuth.m
@@ -278,6 +278,12 @@ static NSString *const kSignInWithGoogle = @"SignInWithGoogle";
   signIn.delegate = self;
   signIn.shouldFetchBasicProfile = YES;
   signIn.clientID = [[FIRApp defaultApp] options].clientID;
+  if (!signIn.clientID) {
+    [NSException raise:NSInternalInconsistencyException
+                format:@"OAuth client ID not found. Please make sure Google Sign-In is enabled in "
+     @"the Firebase console. You may have to download a new GoogleService-Info.plist file after "
+     @"enabling Google Sign-In."];
+  }
   signIn.scopes = _scopes;
   return signIn;
 }


### PR DESCRIPTION
If the `CLIENT_ID` is not present in the GoogleService-Info.plist file, throw an exception with a message prompting the developer to enable Google Sign-In and download a new .plist file.