### PR TITLE
Update minimum iOS version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ FirebaseUI clients are also available for [Android](https://github.com/firebase/
 
 ## Installing FirebaseUI for iOS
 
-FirebaseUI supports iOS 8.0+ and Xcode 11+. We recommend using [CocoaPods](https://cocoapods.org/pods/FirebaseUI), add
+FirebaseUI supports iOS 10.0+ and Xcode 11+. We recommend using [CocoaPods](https://cocoapods.org/pods/FirebaseUI), add
 the following to your `Podfile`:
 
 ```ruby
@@ -47,7 +47,7 @@ pod 'FirebaseUI/Phone', '~> 8.0'
 If you're including FirebaseUI in a Swift project, make sure you also have:
 
 ```ruby
-platform :ios, '9.0'
+platform :ios, '10.0'
 use_frameworks!
 ```
 


### PR DESCRIPTION
Since its 7.0.0 release, Firebase requires iOS 10.0+
