### PR TITLE
Fix test Podfile and eliminate unnecessary podspec dependencies

### DIFF
--- a/FirebaseAuthUI.podspec
+++ b/FirebaseAuthUI.podspec
@@ -17,9 +17,8 @@ Pod::Spec.new do |s|
 
   s.public_header_files = 'FirebaseAuthUI/Sources/Public/FirebaseAuthUI/*.h'
   s.source_files = 'FirebaseAuthUI/Sources/**/*.{h,m}'
-  s.dependency 'Firebase/Auth', '~> 8.0'
-  # s.dependency 'Firebase/Core'
-  # s.dependency 'GoogleUtilities/UserDefaults'
+  s.dependency 'FirebaseAuth', '~> 8.0'
+  s.dependency 'FirebaseCore'
   s.resource_bundles = {
     'FirebaseAuthUI' => ['FirebaseAuthUI/Sources/{Resources,Strings}/*.{xib,png,lproj}']
   }

--- a/FirebaseAuthUI.podspec
+++ b/FirebaseAuthUI.podspec
@@ -17,9 +17,9 @@ Pod::Spec.new do |s|
 
   s.public_header_files = 'FirebaseAuthUI/Sources/Public/FirebaseAuthUI/*.h'
   s.source_files = 'FirebaseAuthUI/Sources/**/*.{h,m}'
-  s.dependency 'FirebaseAuth', '~> 8.0'
-  s.dependency 'FirebaseCore'
-  s.dependency 'GoogleUtilities/UserDefaults'
+  s.dependency 'Firebase/Auth', '~> 8.0'
+  # s.dependency 'Firebase/Core'
+  # s.dependency 'GoogleUtilities/UserDefaults'
   s.resource_bundles = {
     'FirebaseAuthUI' => ['FirebaseAuthUI/Sources/{Resources,Strings}/*.{xib,png,lproj}']
   }

--- a/FirebaseEmailAuthUI.podspec
+++ b/FirebaseEmailAuthUI.podspec
@@ -17,6 +17,8 @@ Pod::Spec.new do |s|
 
   s.public_header_files = 'FirebaseEmailAuthUI/Sources/Public/FirebaseEmailAuthUI/*.h'
   s.source_files = 'FirebaseEmailAuthUI/Sources/**/*.{h,m}'
+  s.dependency 'FirebaseAuth'
+  s.dependency 'FirebaseCore'
   s.dependency 'FirebaseAuthUI'
   s.dependency 'GoogleUtilities/UserDefaults'
   s.resource_bundles = {

--- a/FirebaseEmailAuthUI.podspec
+++ b/FirebaseEmailAuthUI.podspec
@@ -18,8 +18,8 @@ Pod::Spec.new do |s|
   s.public_header_files = 'FirebaseEmailAuthUI/Sources/Public/FirebaseEmailAuthUI/*.h'
   s.source_files = 'FirebaseEmailAuthUI/Sources/**/*.{h,m}'
   s.dependency 'FirebaseAuthUI'
-  s.dependency 'FirebaseAuth', '~> 8.0'
-  s.dependency 'FirebaseCore'
+  # s.dependency 'FirebaseAuth', '~> 8.0'
+  # s.dependency 'FirebaseCore'
   s.dependency 'GoogleUtilities/UserDefaults'
   s.resource_bundles = {
     'FirebaseEmailAuthUI' => ['FirebaseEmailAuthUI/Sources/Resources/*.{xib,png}']

--- a/FirebaseEmailAuthUI.podspec
+++ b/FirebaseEmailAuthUI.podspec
@@ -18,8 +18,6 @@ Pod::Spec.new do |s|
   s.public_header_files = 'FirebaseEmailAuthUI/Sources/Public/FirebaseEmailAuthUI/*.h'
   s.source_files = 'FirebaseEmailAuthUI/Sources/**/*.{h,m}'
   s.dependency 'FirebaseAuthUI'
-  # s.dependency 'FirebaseAuth', '~> 8.0'
-  # s.dependency 'FirebaseCore'
   s.dependency 'GoogleUtilities/UserDefaults'
   s.resource_bundles = {
     'FirebaseEmailAuthUI' => ['FirebaseEmailAuthUI/Sources/Resources/*.{xib,png}']

--- a/FirebaseEmailAuthUI/Podfile
+++ b/FirebaseEmailAuthUI/Podfile
@@ -6,7 +6,9 @@ platform :ios, '10.0'
 target 'FirebaseEmailAuthUI' do
   use_frameworks!
 
-  pod 'FirebaseEmailAuthUI', :path => '../'
+  # The dependencies in the FirebaseEmailAuthUI podspec should be here.
+  pod 'FirebaseAuthUI', :path => '../'
+  pod 'GoogleUtilities/UserDefaults'
 
   target 'FirebaseEmailAuthUITests' do
     inherit! :search_paths

--- a/FirebaseEmailAuthUI/Podfile
+++ b/FirebaseEmailAuthUI/Podfile
@@ -6,7 +6,7 @@ platform :ios, '10.0'
 target 'FirebaseEmailAuthUI' do
   use_frameworks!
 
-  pod 'FirebaseAuthUI', :path => '../'
+  pod 'FirebaseEmailAuthUI', :path => '../'
 
   target 'FirebaseEmailAuthUITests' do
     inherit! :search_paths

--- a/FirebaseEmailAuthUI/Podfile.lock
+++ b/FirebaseEmailAuthUI/Podfile.lock
@@ -23,6 +23,11 @@ PODS:
     - GoogleUtilities/Environment (~> 7.4)
     - GoogleUtilities/Logger (~> 7.4)
     - nanopb (~> 2.30908.0)
+  - FirebaseEmailAuthUI (11.0.3):
+    - FirebaseAuth
+    - FirebaseAuthUI
+    - FirebaseCore
+    - GoogleUtilities/UserDefaults
   - GoogleDataTransport (9.0.1):
     - GoogleUtilities/Environment (~> 7.2)
     - nanopb (~> 2.30908.0)
@@ -54,13 +59,14 @@ PODS:
   - PromisesObjC (1.2.12)
 
 DEPENDENCIES:
-  - FirebaseAuthUI (from `../`)
+  - FirebaseEmailAuthUI (from `../`)
   - OCMock
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - Firebase
     - FirebaseAuth
+    - FirebaseAuthUI
     - FirebaseCore
     - FirebaseCoreDiagnostics
     - GoogleDataTransport
@@ -71,7 +77,7 @@ SPEC REPOS:
     - PromisesObjC
 
 EXTERNAL SOURCES:
-  FirebaseAuthUI:
+  FirebaseEmailAuthUI:
     :path: "../"
 
 SPEC CHECKSUMS:
@@ -80,6 +86,7 @@ SPEC CHECKSUMS:
   FirebaseAuthUI: a44ed5d5da7337fd1dfbd9ac4a32ac3217ea8f2c
   FirebaseCore: 389c4ce9a7cce4a7e25eb22326b4bee0050557b2
   FirebaseCoreDiagnostics: 3e249cee3de5c5f9cfd6cc2a19997231286fec11
+  FirebaseEmailAuthUI: 9d3ef1a6b89049079baaaea254f30c205176ceea
   GoogleDataTransport: 04c3e9a480bbcaa2ec3f5d27f1cdeb6a92f20c8d
   GoogleUtilities: f8a43108b38a68eebe8b3540e1f4f2d28843ce20
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
@@ -87,6 +94,6 @@ SPEC CHECKSUMS:
   OCMock: 29f6e52085b4e7d9b075cbf03ed7c3112f82f934
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
 
-PODFILE CHECKSUM: b25b4ea4616b08b074160df3d9fdb459e8096ef7
+PODFILE CHECKSUM: ffcd9b962954c6351da6f1465db15c02d9909a0a
 
 COCOAPODS: 1.10.1

--- a/FirebaseEmailAuthUI/Podfile.lock
+++ b/FirebaseEmailAuthUI/Podfile.lock
@@ -7,7 +7,6 @@ PODS:
   - FirebaseAuthUI (11.0.3):
     - FirebaseAuth (~> 8.0)
     - FirebaseCore
-    - GoogleUtilities/UserDefaults
   - FirebaseCore (8.1.0):
     - FirebaseCoreDiagnostics (~> 8.0)
     - GoogleUtilities/Environment (~> 7.4)
@@ -49,6 +48,7 @@ PODS:
 
 DEPENDENCIES:
   - FirebaseAuthUI (from `../`)
+  - GoogleUtilities/UserDefaults
   - OCMock
 
 SPEC REPOS:
@@ -69,7 +69,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FirebaseAuth: e069ff5736fe9d5dcf61f36244bb1b1ce1897d17
-  FirebaseAuthUI: 5ae57e5a3ffb821f89491f1b5da9efbdf99ce7cd
+  FirebaseAuthUI: 3f6dcb6f9e1af8e889916e2e0f0f971a70c2d303
   FirebaseCore: 389c4ce9a7cce4a7e25eb22326b4bee0050557b2
   FirebaseCoreDiagnostics: 3e249cee3de5c5f9cfd6cc2a19997231286fec11
   GoogleDataTransport: 04c3e9a480bbcaa2ec3f5d27f1cdeb6a92f20c8d
@@ -79,6 +79,6 @@ SPEC CHECKSUMS:
   OCMock: 29f6e52085b4e7d9b075cbf03ed7c3112f82f934
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
 
-PODFILE CHECKSUM: b25b4ea4616b08b074160df3d9fdb459e8096ef7
+PODFILE CHECKSUM: a4eca46b36587d954fedaeb6300c28f718faab4b
 
 COCOAPODS: 1.10.1

--- a/FirebaseEmailAuthUI/Podfile.lock
+++ b/FirebaseEmailAuthUI/Podfile.lock
@@ -1,19 +1,12 @@
 PODS:
-  - Firebase/Auth (8.1.1):
-    - Firebase/CoreOnly
-    - FirebaseAuth (~> 8.1.0)
-  - Firebase/CoreOnly (8.1.1):
-    - FirebaseCore (= 8.1.0)
   - FirebaseAuth (8.1.0):
     - FirebaseCore (~> 8.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
     - GoogleUtilities/Environment (~> 7.4)
     - GTMSessionFetcher/Core (~> 1.5)
-  - FirebaseAuthUI (11.0.0):
-    - Firebase/Auth (~> 8.0)
-    - FirebaseAuth
+  - FirebaseAuthUI (11.0.3):
+    - FirebaseAuth (~> 8.0)
     - FirebaseCore
-    - GoogleUtilities/UserDefaults
   - FirebaseCore (8.1.0):
     - FirebaseCoreDiagnostics (~> 8.0)
     - GoogleUtilities/Environment (~> 7.4)
@@ -23,11 +16,6 @@ PODS:
     - GoogleUtilities/Environment (~> 7.4)
     - GoogleUtilities/Logger (~> 7.4)
     - nanopb (~> 2.30908.0)
-  - FirebaseEmailAuthUI (11.0.3):
-    - FirebaseAuth
-    - FirebaseAuthUI
-    - FirebaseCore
-    - GoogleUtilities/UserDefaults
   - GoogleDataTransport (9.0.1):
     - GoogleUtilities/Environment (~> 7.2)
     - nanopb (~> 2.30908.0)
@@ -59,14 +47,13 @@ PODS:
   - PromisesObjC (1.2.12)
 
 DEPENDENCIES:
-  - FirebaseEmailAuthUI (from `../`)
+  - FirebaseAuthUI (from `../`)
+  - GoogleUtilities/UserDefaults
   - OCMock
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
-    - Firebase
     - FirebaseAuth
-    - FirebaseAuthUI
     - FirebaseCore
     - FirebaseCoreDiagnostics
     - GoogleDataTransport
@@ -77,16 +64,14 @@ SPEC REPOS:
     - PromisesObjC
 
 EXTERNAL SOURCES:
-  FirebaseEmailAuthUI:
+  FirebaseAuthUI:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Firebase: 4bb49ae87756034cef870fa3c4006235eb46f475
   FirebaseAuth: e069ff5736fe9d5dcf61f36244bb1b1ce1897d17
-  FirebaseAuthUI: a44ed5d5da7337fd1dfbd9ac4a32ac3217ea8f2c
+  FirebaseAuthUI: 3f6dcb6f9e1af8e889916e2e0f0f971a70c2d303
   FirebaseCore: 389c4ce9a7cce4a7e25eb22326b4bee0050557b2
   FirebaseCoreDiagnostics: 3e249cee3de5c5f9cfd6cc2a19997231286fec11
-  FirebaseEmailAuthUI: 9d3ef1a6b89049079baaaea254f30c205176ceea
   GoogleDataTransport: 04c3e9a480bbcaa2ec3f5d27f1cdeb6a92f20c8d
   GoogleUtilities: f8a43108b38a68eebe8b3540e1f4f2d28843ce20
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
@@ -94,6 +79,6 @@ SPEC CHECKSUMS:
   OCMock: 29f6e52085b4e7d9b075cbf03ed7c3112f82f934
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
 
-PODFILE CHECKSUM: ffcd9b962954c6351da6f1465db15c02d9909a0a
+PODFILE CHECKSUM: a4eca46b36587d954fedaeb6300c28f718faab4b
 
 COCOAPODS: 1.10.1

--- a/FirebaseEmailAuthUI/Podfile.lock
+++ b/FirebaseEmailAuthUI/Podfile.lock
@@ -1,12 +1,19 @@
 PODS:
+  - Firebase/Auth (8.1.1):
+    - Firebase/CoreOnly
+    - FirebaseAuth (~> 8.1.0)
+  - Firebase/CoreOnly (8.1.1):
+    - FirebaseCore (= 8.1.0)
   - FirebaseAuth (8.1.0):
     - FirebaseCore (~> 8.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
     - GoogleUtilities/Environment (~> 7.4)
     - GTMSessionFetcher/Core (~> 1.5)
-  - FirebaseAuthUI (11.0.3):
-    - FirebaseAuth (~> 8.0)
+  - FirebaseAuthUI (11.0.0):
+    - Firebase/Auth (~> 8.0)
+    - FirebaseAuth
     - FirebaseCore
+    - GoogleUtilities/UserDefaults
   - FirebaseCore (8.1.0):
     - FirebaseCoreDiagnostics (~> 8.0)
     - GoogleUtilities/Environment (~> 7.4)
@@ -48,11 +55,11 @@ PODS:
 
 DEPENDENCIES:
   - FirebaseAuthUI (from `../`)
-  - GoogleUtilities/UserDefaults
   - OCMock
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
+    - Firebase
     - FirebaseAuth
     - FirebaseCore
     - FirebaseCoreDiagnostics
@@ -68,8 +75,9 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
+  Firebase: 4bb49ae87756034cef870fa3c4006235eb46f475
   FirebaseAuth: e069ff5736fe9d5dcf61f36244bb1b1ce1897d17
-  FirebaseAuthUI: 3f6dcb6f9e1af8e889916e2e0f0f971a70c2d303
+  FirebaseAuthUI: a44ed5d5da7337fd1dfbd9ac4a32ac3217ea8f2c
   FirebaseCore: 389c4ce9a7cce4a7e25eb22326b4bee0050557b2
   FirebaseCoreDiagnostics: 3e249cee3de5c5f9cfd6cc2a19997231286fec11
   GoogleDataTransport: 04c3e9a480bbcaa2ec3f5d27f1cdeb6a92f20c8d
@@ -79,6 +87,6 @@ SPEC CHECKSUMS:
   OCMock: 29f6e52085b4e7d9b075cbf03ed7c3112f82f934
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
 
-PODFILE CHECKSUM: a4eca46b36587d954fedaeb6300c28f718faab4b
+PODFILE CHECKSUM: b25b4ea4616b08b074160df3d9fdb459e8096ef7
 
 COCOAPODS: 1.10.1

--- a/FirebaseFacebookAuthUI.podspec
+++ b/FirebaseFacebookAuthUI.podspec
@@ -20,9 +20,9 @@ Pod::Spec.new do |s|
   s.public_header_files = 'FirebaseFacebookAuthUI/Sources/Public/FirebaseFacebookAuthUI/*.h'
   s.source_files = 'FirebaseFacebookAuthUI/Sources/**/*.{h,m}'
   s.dependency 'FirebaseAuthUI'
-  s.dependency 'FirebaseAuth', '~> 8.0'
-  s.dependency 'FirebaseCore'
-  s.dependency 'GoogleUtilities/UserDefaults'
+  # s.dependency 'FirebaseAuth', '~> 8.0'
+  # s.dependency 'FirebaseCore'
+  # s.dependency 'GoogleUtilities/UserDefaults'
   s.dependency 'FBSDKLoginKit', '~> 9.0'
   s.dependency 'FBSDKCoreKit'
   s.resource_bundles = {

--- a/FirebaseFacebookAuthUI.podspec
+++ b/FirebaseFacebookAuthUI.podspec
@@ -19,10 +19,9 @@ Pod::Spec.new do |s|
   s.platform = :ios, '10.0'
   s.public_header_files = 'FirebaseFacebookAuthUI/Sources/Public/FirebaseFacebookAuthUI/*.h'
   s.source_files = 'FirebaseFacebookAuthUI/Sources/**/*.{h,m}'
+  s.dependency 'FirebaseAuth'
+  s.dependency 'FirebaseCore'
   s.dependency 'FirebaseAuthUI'
-  # s.dependency 'FirebaseAuth', '~> 8.0'
-  # s.dependency 'FirebaseCore'
-  # s.dependency 'GoogleUtilities/UserDefaults'
   s.dependency 'FBSDKLoginKit', '~> 9.0'
   s.dependency 'FBSDKCoreKit'
   s.resource_bundles = {

--- a/FirebaseGoogleAuthUI.podspec
+++ b/FirebaseGoogleAuthUI.podspec
@@ -18,11 +18,10 @@ Pod::Spec.new do |s|
 
   s.public_header_files = 'FirebaseGoogleAuthUI/Sources/Public/FirebaseGoogleAuthUI/*.h'
   s.source_files = 'FirebaseGoogleAuthUI/Sources/**/*.{h,m}'
+  s.dependency 'FirebaseAuth'
+  s.dependency 'FirebaseCore'
   s.dependency 'FirebaseAuthUI'
   s.dependency 'GoogleSignIn', '~> 5.0'
-  # s.dependency 'FirebaseAuth', '~> 8.0'
-  # s.dependency 'FirebaseCore'
-  # s.dependency 'GoogleUtilities/UserDefaults'
   s.resource_bundles = {
     'FirebaseGoogleAuthUI' => ['FirebaseGoogleAuthUI/Sources/{Resources,Strings}/*.{png,lproj}']
   }

--- a/FirebaseGoogleAuthUI.podspec
+++ b/FirebaseGoogleAuthUI.podspec
@@ -20,9 +20,9 @@ Pod::Spec.new do |s|
   s.source_files = 'FirebaseGoogleAuthUI/Sources/**/*.{h,m}'
   s.dependency 'FirebaseAuthUI'
   s.dependency 'GoogleSignIn', '~> 5.0'
-  s.dependency 'FirebaseAuth', '~> 8.0'
-  s.dependency 'FirebaseCore'
-  s.dependency 'GoogleUtilities/UserDefaults'
+  # s.dependency 'FirebaseAuth', '~> 8.0'
+  # s.dependency 'FirebaseCore'
+  # s.dependency 'GoogleUtilities/UserDefaults'
   s.resource_bundles = {
     'FirebaseGoogleAuthUI' => ['FirebaseGoogleAuthUI/Sources/{Resources,Strings}/*.{png,lproj}']
   }

--- a/FirebaseOAuthUI.podspec
+++ b/FirebaseOAuthUI.podspec
@@ -18,9 +18,7 @@ Pod::Spec.new do |s|
   s.public_header_files = 'FirebaseOAuthUI/Sources/Public/FirebaseOAuthUI/*.h'
   s.source_files = 'FirebaseOAuthUI/Sources/**/*.{h,m}'
   s.dependency 'FirebaseAuthUI'
-  # s.dependency 'FirebaseAuth', '~> 8.0'
-  # s.dependency 'FirebaseCore'
-  # s.dependency 'GoogleUtilities/UserDefaults'
+  s.dependency 'FirebaseAuth', '~> 8.0'
   s.resource_bundles = {
     'FirebaseOAuthUI' => ['FirebaseOAuthUI/Sources/{Resources,Strings}/*.{png,lproj}']
   }

--- a/FirebaseOAuthUI.podspec
+++ b/FirebaseOAuthUI.podspec
@@ -18,9 +18,9 @@ Pod::Spec.new do |s|
   s.public_header_files = 'FirebaseOAuthUI/Sources/Public/FirebaseOAuthUI/*.h'
   s.source_files = 'FirebaseOAuthUI/Sources/**/*.{h,m}'
   s.dependency 'FirebaseAuthUI'
-  s.dependency 'FirebaseAuth', '~> 8.0'
-  s.dependency 'FirebaseCore'
-  s.dependency 'GoogleUtilities/UserDefaults'
+  # s.dependency 'FirebaseAuth', '~> 8.0'
+  # s.dependency 'FirebaseCore'
+  # s.dependency 'GoogleUtilities/UserDefaults'
   s.resource_bundles = {
     'FirebaseOAuthUI' => ['FirebaseOAuthUI/Sources/{Resources,Strings}/*.{png,lproj}']
   }

--- a/FirebasePhoneAuthUI.podspec
+++ b/FirebasePhoneAuthUI.podspec
@@ -17,6 +17,7 @@ Pod::Spec.new do |s|
 
   s.public_header_files = 'FirebasePhoneAuthUI/Sources/Public/FirebasePhoneAuthUI/*.h'
   s.source_files = 'FirebasePhoneAuthUI/Sources/**/*.{h,m}'
+  s.dependency 'FirebaseAuth'
   s.dependency 'FirebaseAuthUI'
   s.resource_bundles = {
     'FirebasePhoneAuthUI' => ['FirebasePhoneAuthUI/Sources/{Resources,Strings}/*.{xib,json,lproj,png}']

--- a/FirebasePhoneAuthUI.podspec
+++ b/FirebasePhoneAuthUI.podspec
@@ -18,9 +18,6 @@ Pod::Spec.new do |s|
   s.public_header_files = 'FirebasePhoneAuthUI/Sources/Public/FirebasePhoneAuthUI/*.h'
   s.source_files = 'FirebasePhoneAuthUI/Sources/**/*.{h,m}'
   s.dependency 'FirebaseAuthUI'
-  # s.dependency 'FirebaseAuth', '~> 8.0'
-  # s.dependency 'FirebaseCore'
-  # s.dependency 'GoogleUtilities/UserDefaults'
   s.resource_bundles = {
     'FirebasePhoneAuthUI' => ['FirebasePhoneAuthUI/Sources/{Resources,Strings}/*.{xib,json,lproj,png}']
   }

--- a/FirebasePhoneAuthUI.podspec
+++ b/FirebasePhoneAuthUI.podspec
@@ -18,9 +18,9 @@ Pod::Spec.new do |s|
   s.public_header_files = 'FirebasePhoneAuthUI/Sources/Public/FirebasePhoneAuthUI/*.h'
   s.source_files = 'FirebasePhoneAuthUI/Sources/**/*.{h,m}'
   s.dependency 'FirebaseAuthUI'
-  s.dependency 'FirebaseAuth', '~> 8.0'
-  s.dependency 'FirebaseCore'
-  s.dependency 'GoogleUtilities/UserDefaults'
+  # s.dependency 'FirebaseAuth', '~> 8.0'
+  # s.dependency 'FirebaseCore'
+  # s.dependency 'GoogleUtilities/UserDefaults'
   s.resource_bundles = {
     'FirebasePhoneAuthUI' => ['FirebasePhoneAuthUI/Sources/{Resources,Strings}/*.{xib,json,lproj,png}']
   }

--- a/FirebaseStorageUI.podspec
+++ b/FirebaseStorageUI.podspec
@@ -20,7 +20,6 @@ Pod::Spec.new do |s|
   s.public_header_files = 'FirebaseStorageUI/Sources/Public/FirebaseStorageUI/*.h'
   s.source_files = 'FirebaseStorageUI/Sources/**/*.{h,m}'
   s.dependency 'FirebaseStorage', '~> 8.0'
-  # s.dependency 'GTMSessionFetcher/Core', '~> 1.5.0'
   s.dependency 'SDWebImage', '~> 5.6'
 
 end

--- a/FirebaseStorageUI.podspec
+++ b/FirebaseStorageUI.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.public_header_files = 'FirebaseStorageUI/Sources/Public/FirebaseStorageUI/*.h'
   s.source_files = 'FirebaseStorageUI/Sources/**/*.{h,m}'
   s.dependency 'FirebaseStorage', '~> 8.0'
-  s.dependency 'GTMSessionFetcher/Core', '~> 1.5.0'
+  # s.dependency 'GTMSessionFetcher/Core', '~> 1.5.0'
   s.dependency 'SDWebImage', '~> 5.6'
 
 end

--- a/samples/swift/Podfile.lock
+++ b/samples/swift/Podfile.lock
@@ -233,21 +233,7 @@ PODS:
     - FBSDKLoginKit/Login (= 9.3.0)
   - FBSDKLoginKit/Login (9.3.0):
     - FBSDKCoreKit (~> 9.3.0)
-  - Firebase/Auth (8.0.0):
-    - Firebase/CoreOnly
-    - FirebaseAuth (~> 8.0.0)
-  - Firebase/CoreOnly (8.0.0):
-    - FirebaseCore (= 8.0.0)
-  - Firebase/Database (8.0.0):
-    - Firebase/CoreOnly
-    - FirebaseDatabase (~> 8.0.0)
-  - Firebase/Firestore (8.0.0):
-    - Firebase/CoreOnly
-    - FirebaseFirestore (~> 8.0.0)
-  - Firebase/Storage (8.0.0):
-    - Firebase/CoreOnly
-    - FirebaseStorage (~> 8.0.0)
-  - FirebaseAnonymousAuthUI (11.0.0):
+  - FirebaseAnonymousAuthUI (11.0.3):
     - FirebaseAuth (~> 8.0)
     - FirebaseAuthUI
     - FirebaseCore
@@ -256,11 +242,9 @@ PODS:
     - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
     - GoogleUtilities/Environment (~> 7.4)
     - GTMSessionFetcher/Core (~> 1.5)
-  - FirebaseAuthUI (11.0.0):
-    - Firebase/Auth (~> 8.0)
-    - FirebaseAuth
+  - FirebaseAuthUI (11.0.3):
+    - FirebaseAuth (~> 8.0)
     - FirebaseCore
-    - GoogleUtilities/UserDefaults
   - FirebaseCore (8.0.0):
     - FirebaseCoreDiagnostics (~> 8.0)
     - GoogleUtilities/Environment (~> 7.4)
@@ -273,20 +257,15 @@ PODS:
   - FirebaseDatabase (8.0.0):
     - FirebaseCore (~> 8.0)
     - leveldb-library (~> 1.22)
-  - FirebaseDatabaseUI (11.0.0):
-    - Firebase/Database (~> 8.0)
-  - FirebaseEmailAuthUI (11.0.0):
-    - FirebaseAuth (~> 8.0)
+  - FirebaseDatabaseUI (11.0.3):
+    - FirebaseDatabase (~> 8.0)
+  - FirebaseEmailAuthUI (11.0.3):
     - FirebaseAuthUI
-    - FirebaseCore
     - GoogleUtilities/UserDefaults
-  - FirebaseFacebookAuthUI (11.0.0):
+  - FirebaseFacebookAuthUI (11.0.3):
     - FBSDKCoreKit
     - FBSDKLoginKit (~> 9.0)
-    - FirebaseAuth (~> 8.0)
     - FirebaseAuthUI
-    - FirebaseCore
-    - GoogleUtilities/UserDefaults
   - FirebaseFirestore (8.0.0):
     - abseil/algorithm (= 0.20200225.0)
     - abseil/base (= 0.20200225.0)
@@ -299,63 +278,52 @@ PODS:
     - "gRPC-C++ (~> 1.28.0)"
     - leveldb-library (~> 1.22)
     - nanopb (~> 2.30908.0)
-  - FirebaseFirestoreUI (11.0.0):
-    - Firebase/Firestore
+  - FirebaseFirestoreUI (11.0.3):
     - FirebaseFirestore (~> 8.0)
-  - FirebaseGoogleAuthUI (11.0.0):
-    - FirebaseAuth (~> 8.0)
+  - FirebaseGoogleAuthUI (11.0.3):
     - FirebaseAuthUI
-    - FirebaseCore
     - GoogleSignIn (~> 5.0)
-    - GoogleUtilities/UserDefaults
-  - FirebaseOAuthUI (11.0.0):
+  - FirebaseOAuthUI (11.0.3):
     - FirebaseAuth (~> 8.0)
     - FirebaseAuthUI
-    - FirebaseCore
-    - GoogleUtilities/UserDefaults
-  - FirebasePhoneAuthUI (11.0.0):
-    - FirebaseAuth (~> 8.0)
+  - FirebasePhoneAuthUI (11.0.3):
     - FirebaseAuthUI
-    - FirebaseCore
-    - GoogleUtilities/UserDefaults
   - FirebaseStorage (8.0.0):
     - FirebaseCore (~> 8.0)
     - GTMSessionFetcher/Core (~> 1.5)
-  - FirebaseStorageUI (11.0.0):
-    - Firebase/Storage (~> 8.0)
-    - FirebaseStorage
-    - GTMSessionFetcher/Core (~> 1.5.0)
+  - FirebaseStorageUI (11.0.3):
+    - FirebaseStorage (~> 8.0)
     - SDWebImage (~> 5.6)
-  - FirebaseUI (11.0.0):
-    - FirebaseUI/Anonymous (= 11.0.0)
-    - FirebaseUI/Auth (= 11.0.0)
-    - FirebaseUI/Database (= 11.0.0)
-    - FirebaseUI/Email (= 11.0.0)
-    - FirebaseUI/Facebook (= 11.0.0)
-    - FirebaseUI/Firestore (= 11.0.0)
-    - FirebaseUI/Google (= 11.0.0)
-    - FirebaseUI/OAuth (= 11.0.0)
-    - FirebaseUI/Phone (= 11.0.0)
-    - FirebaseUI/Storage (= 11.0.0)
-  - FirebaseUI/Anonymous (11.0.0):
+  - FirebaseUI (11.0.3):
+    - FirebaseUI/Anonymous (= 11.0.3)
+    - FirebaseUI/Auth (= 11.0.3)
+    - FirebaseUI/Database (= 11.0.3)
+    - FirebaseUI/Email (= 11.0.3)
+    - FirebaseUI/Facebook (= 11.0.3)
+    - FirebaseUI/Firestore (= 11.0.3)
+    - FirebaseUI/Google (= 11.0.3)
+    - FirebaseUI/OAuth (= 11.0.3)
+    - FirebaseUI/Phone (= 11.0.3)
+    - FirebaseUI/Storage (= 11.0.3)
+  - FirebaseUI/Anonymous (11.0.3):
     - FirebaseAnonymousAuthUI (~> 11.0)
-  - FirebaseUI/Auth (11.0.0):
+  - FirebaseUI/Auth (11.0.3):
     - FirebaseAuthUI (~> 11.0)
-  - FirebaseUI/Database (11.0.0):
+  - FirebaseUI/Database (11.0.3):
     - FirebaseDatabaseUI (~> 11.0)
-  - FirebaseUI/Email (11.0.0):
+  - FirebaseUI/Email (11.0.3):
     - FirebaseEmailAuthUI (~> 11.0)
-  - FirebaseUI/Facebook (11.0.0):
+  - FirebaseUI/Facebook (11.0.3):
     - FirebaseFacebookAuthUI (~> 11.0)
-  - FirebaseUI/Firestore (11.0.0):
+  - FirebaseUI/Firestore (11.0.3):
     - FirebaseFirestoreUI (~> 11.0)
-  - FirebaseUI/Google (11.0.0):
+  - FirebaseUI/Google (11.0.3):
     - FirebaseGoogleAuthUI (~> 11.0)
-  - FirebaseUI/OAuth (11.0.0):
+  - FirebaseUI/OAuth (11.0.3):
     - FirebaseOAuthUI (~> 11.0)
-  - FirebaseUI/Phone (11.0.0):
+  - FirebaseUI/Phone (11.0.3):
     - FirebasePhoneAuthUI (~> 11.0)
-  - FirebaseUI/Storage (11.0.0):
+  - FirebaseUI/Storage (11.0.3):
     - FirebaseStorageUI (~> 11.0)
   - GoogleDataTransport (9.0.0):
     - GoogleUtilities/Environment (~> 7.2)
@@ -441,7 +409,6 @@ SPEC REPOS:
     - BoringSSL-GRPC
     - FBSDKCoreKit
     - FBSDKLoginKit
-    - Firebase
     - FirebaseAuth
     - FirebaseCore
     - FirebaseCoreDiagnostics
@@ -490,24 +457,23 @@ SPEC CHECKSUMS:
   BoringSSL-GRPC: 8edf627ee524575e2f8d19d56f068b448eea3879
   FBSDKCoreKit: 0d1ae58388a458b8222f72025804cdc84eb5d0c3
   FBSDKLoginKit: aea68df6121c5e165ccae2fabfdc83c4644ee40f
-  Firebase: 73c3e3b216ec1ecbc54d2ffdd4670c65c749edb1
-  FirebaseAnonymousAuthUI: 250139e53ca84bb18b9cd67e35be0d4d63e22418
+  FirebaseAnonymousAuthUI: 64de9383870378e8f16ef428d73e8c18e74ce5cc
   FirebaseAuth: b8cd992fca5b53dc6eec09e873a3f375f000c5a1
-  FirebaseAuthUI: a44ed5d5da7337fd1dfbd9ac4a32ac3217ea8f2c
+  FirebaseAuthUI: 3f6dcb6f9e1af8e889916e2e0f0f971a70c2d303
   FirebaseCore: 3f09591d51292843e2a46f18358d60bf4e996255
   FirebaseCoreDiagnostics: a31d987ba0fe16d59886a5dbadc2f1de871f88c8
   FirebaseDatabase: 363961e25451425be8b14bb8801a592515ec58f2
-  FirebaseDatabaseUI: 0b304b9fbecd35c2809cd3a99e902d6f26307fba
-  FirebaseEmailAuthUI: 6548e3456fd339e73a8e9b5e7825b29863d8ba00
-  FirebaseFacebookAuthUI: 757715ef67ee9511fc2da6f7120feeca82949be1
+  FirebaseDatabaseUI: 4db2acaaee3c1a73e0daf31e926a8b7212941607
+  FirebaseEmailAuthUI: ff51c964f327eb38ed1f3ac27057c090d4955b01
+  FirebaseFacebookAuthUI: a8407d457cef6b1996de11c0ecde03b9a9dc1691
   FirebaseFirestore: 7f6576eaca9f821e864c3e917d68aa99f4e6b613
-  FirebaseFirestoreUI: 9f3d679531e47299a45790599e3737c6e3920211
-  FirebaseGoogleAuthUI: eea5adfab55c5a9f1789510e342306b7351d7c2f
-  FirebaseOAuthUI: 1d34e7784438663b08c68e9c1cea131abe1e34b0
-  FirebasePhoneAuthUI: 94d6ba23d0b2cf89dff3dbcaad39fccab355cb67
+  FirebaseFirestoreUI: 24a7a35da1a570e8aabd592f60de9438f6959a4c
+  FirebaseGoogleAuthUI: 95ac66fd249c6f6d47b53b6b578d3fe5a940db5c
+  FirebaseOAuthUI: 9f2f90a6cf72f1345473d205ff2071b994a071d8
+  FirebasePhoneAuthUI: f494446c505cea2530b4d2dc44a7918be2836fb7
   FirebaseStorage: 61bcd27880fa17362f68be67d3683d04bfd7b1c7
-  FirebaseStorageUI: e93c9c7ff0b1d565920078e503479b18061e224d
-  FirebaseUI: 4898197e31eeff47b8a99dcd7849ded186ac8af4
+  FirebaseStorageUI: d66a62c897de1d0f279ec80c7ece6b8afc9c5913
+  FirebaseUI: d2777b3abcb3fa40ea9eea9e40db5a154df608d3
   GoogleDataTransport: 11e3a5f2c190327df1a4a5d7e7ae3d4d5b9c9e4c
   GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
   GoogleUtilities: f8a43108b38a68eebe8b3540e1f4f2d28843ce20


### PR DESCRIPTION
Pull request to expose https://github.com/firebase/firebase-ios-sdk/issues/8137.

To repro, `cd samples/swift` and run a `pod install`. The app target should fail to build with some linker errors:

```
Undefined symbols for architecture x86_64:
  "_FIRFacebookAuthProviderID", referenced from:
      +[FUIAuthBaseViewController providerLocalizedName:] in FUIAuthBaseViewController.o
  "_OBJC_CLASS_$_FIRApp", referenced from:
      objc-class-ref in FUIAuth.o
      objc-class-ref in FUIAuthStrings.o
  "_OBJC_CLASS_$_FIRAuth", referenced from:
      objc-class-ref in FUIAuth.o
  "_FIRAuthErrorUserInfoUpdatedCredentialKey", referenced from:
      ___95-[FUIAuth autoUpgradeAccountWithProviderUI:presentingViewController:credential:resultCallback:]_block_invoke in FUIAuth.o
  "_FIRTwitterAuthProviderID", referenced from:
      +[FUIAuthBaseViewController providerLocalizedName:] in FUIAuthBaseViewController.o
  "_FIRGoogleAuthProviderID", referenced from:
      +[FUIAuthBaseViewController providerLocalizedName:] in FUIAuthBaseViewController.o
  "_FIREmailAuthProviderID", referenced from:
      ___75-[FUIAccountSettingsOperation showVerifyDialogWithMessage:providerHandler:]_block_invoke in FUIAccountSettingsOperation.o
      ___67-[FUIAccountSettingsOperationDeleteAccount showDeleteAccountDialog]_block_invoke in FUIAccountSettingsOperationDeleteAccount.o
      -[FUIAccountSettingsViewController accountState] in FUIAccountSettingsViewController.o
      -[FUIAccountSettingsViewController updateTableStateLinkedAccountWithoutEmail] in FUIAccountSettingsViewController.o
      -[FUIAccountSettingsViewController updateTableStateLinkedAccountWithEmail] in FUIAccountSettingsViewController.o
      -[FUIAccountSettingsViewController updateTableStateLinkedAccountWithEmailPassword] in FUIAccountSettingsViewController.o
      +[FUIAuthBaseViewController providerLocalizedName:] in FUIAuthBaseViewController.o
```