### PR TITLE
initWithAuthUI: Auth Fix

### DIFF
--- a/FirebaseOAuthUI/FirebaseOAuthUITests/FirebaseOAuthUITests.m
+++ b/FirebaseOAuthUI/FirebaseOAuthUITests/FirebaseOAuthUITests.m
@@ -42,7 +42,7 @@
   OCMStub([authClass app]).andReturn(appClass);
 
   self.mockOAuthProvider = OCMClassMock([FIROAuthProvider class]);
-  OCMStub(ClassMethod([_mockOAuthProvider providerWithProviderID:OCMOCK_ANY])).
+  OCMStub(ClassMethod([_mockOAuthProvider providerWithProviderID:OCMOCK_ANY auth:OCMOCK_ANY])).
       andReturn(_mockOAuthProvider);
 
   FIRAuth *auth = [FIRAuth auth];

--- a/FirebaseOAuthUI/FirebaseOAuthUITests/FirebaseOAuthUITests.m
+++ b/FirebaseOAuthUI/FirebaseOAuthUITests/FirebaseOAuthUITests.m
@@ -40,13 +40,13 @@
 
   id appClass = OCMClassMock([FIRApp class]);
   OCMStub([authClass app]).andReturn(appClass);
-
-  self.mockOAuthProvider = OCMClassMock([FIROAuthProvider class]);
-  OCMStub(ClassMethod([_mockOAuthProvider providerWithProviderID:OCMOCK_ANY auth:OCMOCK_ANY])).
-      andReturn(_mockOAuthProvider);
-
+  
   FIRAuth *auth = [FIRAuth auth];
   self.authUI = [FUIAuth authUIWithAuth:auth];
+
+  self.mockOAuthProvider = OCMClassMock([FIROAuthProvider class]);
+  OCMStub(ClassMethod([_mockOAuthProvider providerWithProviderID:OCMOCK_ANY auth:self.authUI.auth])).
+      andReturn(_mockOAuthProvider);
 }
 
 - (void)tearDown {
@@ -78,7 +78,7 @@
   XCTAssertNil(self.provider.accessToken);
   XCTAssertNil(self.provider.idToken);
 
-  OCMVerify([self.mockOAuthProvider providerWithProviderID:@"dummy"]);
+  OCMVerify([self.mockOAuthProvider providerWithProviderID:@"dummy" auth:self.authUI.auth]);
 }
 
 - (void)testAppleUsesEmulatorCreatesOAuthProvider {
@@ -93,7 +93,7 @@
                                             scopes:@[]
                                   customParameters:@{}
                                       loginHintKey:nil];
-  OCMVerify([self.mockOAuthProvider providerWithProviderID:@"apple.com"]);
+  OCMVerify([self.mockOAuthProvider providerWithProviderID:@"apple.com" auth:self.authUI.auth]);
 }
 
 - (void)testAppleNoUseEmulatorNoOAuthProvider {
@@ -106,7 +106,7 @@
                                             scopes:@[]
                                   customParameters:@{}
                                       loginHintKey:nil];
-  OCMVerify(never(), [self.mockOAuthProvider providerWithProviderID:@"apple.com"]);
+  OCMVerify(never(), [self.mockOAuthProvider providerWithProviderID:@"apple.com" auth:self.authUI.auth]);
 }
 
 @end

--- a/FirebaseOAuthUI/Sources/FUIOAuth.m
+++ b/FirebaseOAuthUI/Sources/FUIOAuth.m
@@ -136,7 +136,7 @@ NS_ASSUME_NONNULL_BEGIN
     _customParameters = customParameters;
     _loginHintKey = loginHintKey;
     if ((_authUI.isEmulatorEnabled || ![_providerID isEqualToString:@"apple.com"]) && ![_providerID isEqualToString:@"facebook.com"]) {
-      _provider = [FIROAuthProvider providerWithProviderID:self.providerID];
+      _provider = [FIROAuthProvider providerWithProviderID:self.providerID auth:_authUI.auth];
     }
   }
   return self;


### PR DESCRIPTION
When custom FIRAuth is used, it needs to be passed to create AuthProvider. 
This fix is required for auth providers like Twitter.
Related PR: #974 
