### PR TITLE
Change Apple sign in button to center aligned

### DIFF
--- a/FirebaseOAuthUI/Sources/FUIOAuth.m
+++ b/FirebaseOAuthUI/Sources/FUIOAuth.m
@@ -256,7 +256,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                  scopes:@[@"name", @"email"]
                                        customParameters:nil
                                            loginHintKey:nil];
-  provider.buttonAlignment = FUIButtonAlignmentLeading;
+  provider.buttonAlignment = FUIButtonAlignmentCenter;
   provider.buttonTextColor = buttonTextColor;
   return provider;
 }


### PR DESCRIPTION
Fixes #1008 

Updated the apple sign in button to match [Apple HIG](https://developer.apple.com/design/human-interface-guidelines/sign-in-with-apple/overview/introduction/).