### PR TITLE
Should callback Apple's error status instead of doing nothing (canceled/failed/invalid/Nothandled/Unknown)

### DIFF
--- a/FirebaseOAuthUI/Sources/FUIOAuth.m
+++ b/FirebaseOAuthUI/Sources/FUIOAuth.m
@@ -399,7 +399,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)authorizationController:(ASAuthorizationController *)controller didCompleteWithError:(NSError *)error API_AVAILABLE(ios(13.0)) {
-  NSLog(@"%@", error.description);
+    NSLog(@"%@", error.description);
+    // canceled/failed/invalid/Nothandled/Unknown
+    if (_providerSignInCompletion) {
+        _providerSignInCompletion(nil, error, nil, nil);
+    }
 }
 
 #pragma mark - ASAuthorizationControllerPresentationContextProviding


### PR DESCRIPTION
When I log in with Apple and I have been waiting for a callback, but due to some internal Apple reasons, there has been no callback, which caused me to be unable to determine what happened.