### PR TITLE
Should callback Apple's error status instead of doing nothing (canceled/failed/invalid/Nothandled/Unknown)

### DIFF
--- a/FirebaseOAuthUI/Sources/FUIOAuth.m
+++ b/FirebaseOAuthUI/Sources/FUIOAuth.m
@@ -399,7 +399,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)authorizationController:(ASAuthorizationController *)controller didCompleteWithError:(NSError *)error API_AVAILABLE(ios(13.0)) {
-  NSLog(@"%@", error.description);
+    NSLog(@"%@", error.description);
+    // canceled/failed/invalid/Nothandled/Unknown
+    if (_providerSignInCompletion) {
+        _providerSignInCompletion(nil, error, nil, nil);
+    }
 }
 
 #pragma mark - ASAuthorizationControllerPresentationContextProviding


### PR DESCRIPTION

When I log in with Apple, I have been waiting for a callback, but due to some errors within Apple, there has been no callback, so I can't determine what happened. So I think the error generated by apple should be called back here so that the developer knows what happened.
