### PR TITLE
Update FUIAuth.m

### DIFF
--- a/FirebaseAuthUI/Sources/FUIAuth.m
+++ b/FirebaseAuthUI/Sources/FUIAuth.m
@@ -201,7 +201,8 @@ static NSString *const kFirebaseAuthUIFrameworkMarker = @"FirebaseUI-iOS";
       [self.auth signInWithCredential:credential
                            completion:^(FIRAuthDataResult *_Nullable authResult,
                                         NSError *_Nullable error) {
-        if (error && error.code == FIRAuthErrorCodeAccountExistsWithDifferentCredential) {
+        if (self.emailAuthProvider && error 
+            && error.code == FIRAuthErrorCodeAccountExistsWithDifferentCredential) {
           NSString *email = error.userInfo[kErrorUserInfoEmailKey];
           [self.emailAuthProvider handleAccountLinkingForEmail:email
                                                  newCredential:credential


### PR DESCRIPTION
Prevent an error from being swallowed in the case of FIRAuthErrorCodeAccountExistsWithDifferentCredential when the emailAiuthProvider is nil.

Hey there! So you want to contribute to FirebaseUI? Before you file this pull request, follow these steps:

  * Read [the contribution guidelines](CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to mention the issue number here.  If not, go file an issue about this to make sure this is a desirable change.
  * If this is a new feature please co-ordinate with someone on [FirebaseUI-Android](https://github.com/firebase/firebaseui-android) to make sure that we can implement this on both platforms and maintain feature parity.
