### PR TITLE
[Firebase 9] Add spec `swift_version`

### DIFF
--- a/FirebaseAnonymousAuthUI.podspec
+++ b/FirebaseAnonymousAuthUI.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"',
   }
+  s.swift_version = '5.3'
 
   s.public_header_files = 'FirebaseAnonymousAuthUI/Sources/Public/FirebaseAnonymousAuthUI/*.h'
   s.source_files = 'FirebaseAnonymousAuthUI/Sources/**/*.{h,m}'

--- a/FirebaseAuthUI.podspec
+++ b/FirebaseAuthUI.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"',
   }
+  s.swift_version = '5.3'
 
   s.public_header_files = 'FirebaseAuthUI/Sources/Public/FirebaseAuthUI/*.h'
   s.source_files = 'FirebaseAuthUI/Sources/**/*.{h,m}'

--- a/FirebaseDatabaseUI.podspec
+++ b/FirebaseDatabaseUI.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"',
   }
+  s.swift_version = '5.3'
 
   s.public_header_files = 'FirebaseDatabaseUI/Sources/Public/FirebaseDatabaseUI/*.h'
   s.source_files = 'FirebaseDatabaseUI/Sources/**/*.{h,m}'

--- a/FirebaseEmailAuthUI.podspec
+++ b/FirebaseEmailAuthUI.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"',
   }
+  s.swift_version = '5.3'
 
   s.public_header_files = 'FirebaseEmailAuthUI/Sources/Public/FirebaseEmailAuthUI/*.h'
   s.source_files = 'FirebaseEmailAuthUI/Sources/**/*.{h,m}'

--- a/FirebaseFacebookAuthUI.podspec
+++ b/FirebaseFacebookAuthUI.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"',
   }
+  s.swift_version = '5.3'
 
   s.platform = :ios, '10.0'
   s.public_header_files = 'FirebaseFacebookAuthUI/Sources/Public/FirebaseFacebookAuthUI/*.h'

--- a/FirebaseFirestoreUI.podspec
+++ b/FirebaseFirestoreUI.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"',
   }
+  s.swift_version = '5.3'
 
   s.public_header_files = 'FirebaseFirestoreUI/Sources/Public/FirebaseFirestoreUI/*.h'
   s.source_files = 'FirebaseFirestoreUI/Sources/**/*.{h,m}'

--- a/FirebaseGoogleAuthUI.podspec
+++ b/FirebaseGoogleAuthUI.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"',
   }
+  s.swift_version = '5.3'
 
   s.public_header_files = 'FirebaseGoogleAuthUI/Sources/Public/FirebaseGoogleAuthUI/*.h'
   s.source_files = 'FirebaseGoogleAuthUI/Sources/**/*.{h,m}'

--- a/FirebaseOAuthUI.podspec
+++ b/FirebaseOAuthUI.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"',
   }
+  s.swift_version = '5.3'
 
   s.public_header_files = 'FirebaseOAuthUI/Sources/Public/FirebaseOAuthUI/*.h'
   s.source_files = 'FirebaseOAuthUI/Sources/**/*.{h,m}'

--- a/FirebasePhoneAuthUI.podspec
+++ b/FirebasePhoneAuthUI.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"',
   }
+  s.swift_version = '5.3'
 
   s.public_header_files = 'FirebasePhoneAuthUI/Sources/Public/FirebasePhoneAuthUI/*.h'
   s.source_files = 'FirebasePhoneAuthUI/Sources/**/*.{h,m}'

--- a/FirebaseStorageUI.podspec
+++ b/FirebaseStorageUI.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"',
   }
+  s.swift_version = '5.3'
 
   s.tvos.deployment_target = '11.0'
   s.public_header_files = 'FirebaseStorageUI/Sources/Public/FirebaseStorageUI/*.h'

--- a/FirebaseUI.podspec
+++ b/FirebaseUI.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.public_header_files = 'FirebaseUI.h'
   s.source_files = 'FirebaseUI.h'
-  s.swift_versions = '5.0'
+  s.swift_versions = '5.3'
   s.cocoapods_version = '>= 1.8.0'
   s.pod_target_xcconfig = {
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"',


### PR DESCRIPTION
Come Firebase 9, all SDKs that depend on Firebase will need to specify a `swift_version`.

I've set the `swift_version` of all specs to match that of Firebase.

#no-changelog