### PR TITLE
Update FirebaseUI for v8.x and v9.x compatibility

### DIFF
--- a/FirebaseAnonymousAuthUI.podspec
+++ b/FirebaseAnonymousAuthUI.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary      = 'Provides anonymous auth support for FirebaseAuthUI.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }
-  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'pre' + s.version.to_s}
+  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'v' + s.version.to_s}
   s.author       = 'Firebase'
   s.platform = :ios
   s.ios.deployment_target = '10.0'

--- a/FirebaseAnonymousAuthUI.podspec
+++ b/FirebaseAnonymousAuthUI.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseAnonymousAuthUI'
-  s.version      = '12.1.1'
+  s.version      = '12.2.0'
   s.summary      = 'Provides anonymous auth support for FirebaseAuthUI.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }
-  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'v' + s.version.to_s}
+  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'pre' + s.version.to_s}
   s.author       = 'Firebase'
   s.platform = :ios
   s.ios.deployment_target = '10.0'
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.public_header_files = 'FirebaseAnonymousAuthUI/Sources/Public/FirebaseAnonymousAuthUI/*.h'
   s.source_files = 'FirebaseAnonymousAuthUI/Sources/**/*.{h,m}'
   s.dependency 'FirebaseAuthUI'
-  s.dependency 'FirebaseAuth', '~> 8.0'
+  s.dependency 'FirebaseAuth', '>= 8.0', '< 10.0'
   s.dependency 'FirebaseCore'
   s.resource_bundles = {
     'FirebaseAnonymousAuthUI' => [

--- a/FirebaseAuthUI.podspec
+++ b/FirebaseAuthUI.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseAuthUI'
-  s.version      = '12.1.1'
+  s.version      = '12.2.0'
   s.summary      = 'A prebuilt authentication UI flow for Firebase Auth.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }
-  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'v' + s.version.to_s}
+  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'pre' + s.version.to_s}
   s.author       = 'Firebase'
   s.platform = :ios
   s.ios.deployment_target = '10.0'
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
 
   s.public_header_files = 'FirebaseAuthUI/Sources/Public/FirebaseAuthUI/*.h'
   s.source_files = 'FirebaseAuthUI/Sources/**/*.{h,m}'
-  s.dependency 'FirebaseAuth', '~> 8.0'
+  s.dependency 'FirebaseAuth', '>= 8.0', '< 10.0'
   s.dependency 'FirebaseCore'
   s.resource_bundles = {
     'FirebaseAuthUI' => ['FirebaseAuthUI/Sources/{Resources,Strings}/*.{xib,png,lproj}']

--- a/FirebaseAuthUI.podspec
+++ b/FirebaseAuthUI.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary      = 'A prebuilt authentication UI flow for Firebase Auth.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }
-  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'pre' + s.version.to_s}
+  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'v' + s.version.to_s}
   s.author       = 'Firebase'
   s.platform = :ios
   s.ios.deployment_target = '10.0'

--- a/FirebaseDatabaseUI.podspec
+++ b/FirebaseDatabaseUI.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseDatabaseUI'
-  s.version      = '12.1.1'
+  s.version      = '12.2.0'
   s.summary      = 'Prebuilt data sources and UI bindings for Firebase Database.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }
-  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'v' + s.version.to_s}
+  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'pre' + s.version.to_s}
   s.author       = 'Firebase'
   s.platform = :ios
   s.ios.deployment_target = '10.0'
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
 
   s.public_header_files = 'FirebaseDatabaseUI/Sources/Public/FirebaseDatabaseUI/*.h'
   s.source_files = 'FirebaseDatabaseUI/Sources/**/*.{h,m}'
-  s.dependency 'FirebaseDatabase', '~> 8.0'
+  s.dependency 'FirebaseDatabase', '>= 8.0', '< 10.0'
 
 end

--- a/FirebaseDatabaseUI.podspec
+++ b/FirebaseDatabaseUI.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary      = 'Prebuilt data sources and UI bindings for Firebase Database.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }
-  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'pre' + s.version.to_s}
+  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'v' + s.version.to_s}
   s.author       = 'Firebase'
   s.platform = :ios
   s.ios.deployment_target = '10.0'

--- a/FirebaseEmailAuthUI.podspec
+++ b/FirebaseEmailAuthUI.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseEmailAuthUI'
-  s.version      = '12.1.1'
+  s.version      = '12.2.0'
   s.summary      = 'An email authentication provider for FirebaseAuthUI.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }
-  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'v' + s.version.to_s}
+  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'pre' + s.version.to_s}
   s.author       = 'Firebase'
   s.platform = :ios
   s.ios.deployment_target = '10.0'

--- a/FirebaseEmailAuthUI.podspec
+++ b/FirebaseEmailAuthUI.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary      = 'An email authentication provider for FirebaseAuthUI.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }
-  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'pre' + s.version.to_s}
+  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'v' + s.version.to_s}
   s.author       = 'Firebase'
   s.platform = :ios
   s.ios.deployment_target = '10.0'

--- a/FirebaseFacebookAuthUI.podspec
+++ b/FirebaseFacebookAuthUI.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseFacebookAuthUI'
-  s.version      = '12.1.1'
+  s.version      = '12.2.0'
   s.summary      = 'A Facebook auth provider for FirebaseAuthUI.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }
-  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'v' + s.version.to_s}
+  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'pre' + s.version.to_s}
   s.author       = 'Firebase'
   s.platform = :ios
   s.ios.deployment_target = '10.0'

--- a/FirebaseFacebookAuthUI.podspec
+++ b/FirebaseFacebookAuthUI.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary      = 'A Facebook auth provider for FirebaseAuthUI.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }
-  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'pre' + s.version.to_s}
+  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'v' + s.version.to_s}
   s.author       = 'Firebase'
   s.platform = :ios
   s.ios.deployment_target = '10.0'

--- a/FirebaseFirestoreUI.podspec
+++ b/FirebaseFirestoreUI.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseFirestoreUI'
-  s.version      = '12.1.1'
+  s.version      = '12.2.0'
   s.summary      = 'Data libraries and UI bindings for Firestore.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }
-  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'v' + s.version.to_s}
+  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'pre' + s.version.to_s}
   s.author       = 'Firebase'
   s.platform = :ios
   s.ios.deployment_target = '10.0'
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
 
   s.public_header_files = 'FirebaseFirestoreUI/Sources/Public/FirebaseFirestoreUI/*.h'
   s.source_files = 'FirebaseFirestoreUI/Sources/**/*.{h,m}'
-  s.dependency 'FirebaseFirestore', '~> 8.0'
+  s.dependency 'FirebaseFirestore', '>= 8.0', '< 10.0'
 
 end

--- a/FirebaseFirestoreUI.podspec
+++ b/FirebaseFirestoreUI.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary      = 'Data libraries and UI bindings for Firestore.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }
-  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'pre' + s.version.to_s}
+  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'v' + s.version.to_s}
   s.author       = 'Firebase'
   s.platform = :ios
   s.ios.deployment_target = '10.0'

--- a/FirebaseGoogleAuthUI.podspec
+++ b/FirebaseGoogleAuthUI.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary      = 'Google authentication for FirebaseAuthUI.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }
-  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'pre' + s.version.to_s}
+  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'v' + s.version.to_s}
   s.author       = 'Firebase'
   s.platform = :ios
   s.ios.deployment_target = '10.0'

--- a/FirebaseGoogleAuthUI.podspec
+++ b/FirebaseGoogleAuthUI.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseGoogleAuthUI'
-  s.version      = '12.1.1'
+  s.version      = '12.2.0'
   s.summary      = 'Google authentication for FirebaseAuthUI.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }
-  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'v' + s.version.to_s}
+  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'pre' + s.version.to_s}
   s.author       = 'Firebase'
   s.platform = :ios
   s.ios.deployment_target = '10.0'

--- a/FirebaseOAuthUI.podspec
+++ b/FirebaseOAuthUI.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary      = 'A collection of OAuth providers for FirebaseAuthUI.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }
-  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'pre' + s.version.to_s}
+  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'v' + s.version.to_s}
   s.author       = 'Firebase'
   s.platform = :ios
   s.ios.deployment_target = '10.0'

--- a/FirebaseOAuthUI.podspec
+++ b/FirebaseOAuthUI.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseOAuthUI'
-  s.version      = '12.1.1'
+  s.version      = '12.2.0'
   s.summary      = 'A collection of OAuth providers for FirebaseAuthUI.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }
-  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'v' + s.version.to_s}
+  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'pre' + s.version.to_s}
   s.author       = 'Firebase'
   s.platform = :ios
   s.ios.deployment_target = '10.0'
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.public_header_files = 'FirebaseOAuthUI/Sources/Public/FirebaseOAuthUI/*.h'
   s.source_files = 'FirebaseOAuthUI/Sources/**/*.{h,m}'
   s.dependency 'FirebaseAuthUI', '>= 12.0.2', '< 13.0'
-  s.dependency 'FirebaseAuth', '~> 8.0'
+  s.dependency 'FirebaseAuth', '>= 8.0', '< 10.0'
   s.resource_bundles = {
     'FirebaseOAuthUI' => ['FirebaseOAuthUI/Sources/{Resources,Strings}/*.{png,lproj}']
   }

--- a/FirebasePhoneAuthUI.podspec
+++ b/FirebasePhoneAuthUI.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary      = 'A phone auth provider for FirebaseAuthUI.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }
-  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'pre' + s.version.to_s}
+  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'v' + s.version.to_s}
   s.author       = 'Firebase'
   s.platform = :ios
   s.ios.deployment_target = '10.0'

--- a/FirebasePhoneAuthUI.podspec
+++ b/FirebasePhoneAuthUI.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebasePhoneAuthUI'
-  s.version      = '12.1.1'
+  s.version      = '12.2.0'
   s.summary      = 'A phone auth provider for FirebaseAuthUI.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }
-  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'v' + s.version.to_s}
+  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'pre' + s.version.to_s}
   s.author       = 'Firebase'
   s.platform = :ios
   s.ios.deployment_target = '10.0'

--- a/FirebaseStorageUI.podspec
+++ b/FirebaseStorageUI.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseStorageUI'
-  s.version      = '12.1.1'
+  s.version      = '12.2.0'
   s.summary      = 'UI binding libraries for Firebase.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }
-  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'v' + s.version.to_s}
+  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'pre' + s.version.to_s}
   s.author       = 'Firebase'
   s.platform = :ios
   s.ios.deployment_target = '10.0'
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '11.0'
   s.public_header_files = 'FirebaseStorageUI/Sources/Public/FirebaseStorageUI/*.h'
   s.source_files = 'FirebaseStorageUI/Sources/**/*.{h,m}'
-  s.dependency 'FirebaseStorage', '~> 8.0'
+  s.dependency 'FirebaseStorage', '>= 8.0', '< 10.0'
   s.dependency 'SDWebImage', '~> 5.6'
 
 end

--- a/FirebaseStorageUI.podspec
+++ b/FirebaseStorageUI.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary      = 'UI binding libraries for Firebase.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }
-  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'pre' + s.version.to_s}
+  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'v' + s.version.to_s}
   s.author       = 'Firebase'
   s.platform = :ios
   s.ios.deployment_target = '10.0'

--- a/FirebaseStorageUI/Sources/FUIStorageImageLoader.m
+++ b/FirebaseStorageUI/Sources/FUIStorageImageLoader.m
@@ -18,7 +18,13 @@
 #import "FirebaseStorageUI/Sources/Public/FirebaseStorageUI/FIRStorageDownloadTask+SDWebImage.h"
 
 #import <FirebaseCore/FirebaseCore.h>
-#import <FirebaseStorage/FirebaseStorage.h>
+#if __has_include(<FirebaseStorage/FirebaseStorage.h>)
+  // Firebase 8.x
+  #import <FirebaseStorage/FirebaseStorage.h>
+#else
+  // Firebase 9.0+
+  #import <FirebaseStorage/FirebaseStorage-Swift.h>
+#endif
 
 #if SWIFT_PACKAGE
 @import GTMSessionFetcherCore;
@@ -120,7 +126,7 @@
   [download observeStatus:FIRStorageTaskStatusProgress handler:^(FIRStorageTaskSnapshot * _Nonnull snapshot) {
     // Check progressive decoding if need
     if (options & SDWebImageProgressiveLoad) {
-      FIRStorageDownloadTask *task = snapshot.task;
+      FIRStorageDownloadTask *task = (FIRStorageDownloadTask *)snapshot.task;
       // Currently, FIRStorageDownloadTask does not have the API to grab partial data
       // But since FirebaseUI and Firebase are seamless component, we access the internal fetcher here
       GTMSessionFetcher *fetcher = task.fetcher;
@@ -160,7 +166,7 @@
 }
 
 - (BOOL)shouldBlockFailedURLWithURL:(NSURL *)url error:(NSError *)error {
-  if ([error.domain isEqualToString:FIRStorageErrorDomain]) {
+  if ([error.domain isEqualToString:@"FIRStorageErrorDomain"]) {
     if (error.code == FIRStorageErrorCodeBucketNotFound
         || error.code == FIRStorageErrorCodeProjectNotFound
         || error.code == FIRStorageErrorCodeObjectNotFound) {

--- a/FirebaseStorageUI/Sources/Public/FirebaseStorageUI/FIRStorageDownloadTask+SDWebImage.h
+++ b/FirebaseStorageUI/Sources/Public/FirebaseStorageUI/FIRStorageDownloadTask+SDWebImage.h
@@ -14,7 +14,13 @@
 //  limitations under the License.
 //
 
-#import <FirebaseStorage/FirebaseStorage.h>
+#if __has_include(<FirebaseStorage/FirebaseStorage.h>)
+  // Firebase 8.x
+  #import <FirebaseStorage/FirebaseStorage.h>
+#else
+  // Firebase 9.0+
+  #import <FirebaseStorage/FirebaseStorage-Swift.h>
+#endif
 #import <SDWebImage/SDWebImage.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/FirebaseStorageUI/Sources/Public/FirebaseStorageUI/FUIStorageDefine.h
+++ b/FirebaseStorageUI/Sources/Public/FirebaseStorageUI/FUIStorageDefine.h
@@ -14,7 +14,13 @@
 //  limitations under the License.
 //
 
-#import <FirebaseStorage/FirebaseStorage.h>
+#if __has_include(<FirebaseStorage/FirebaseStorage.h>)
+  // Firebase 8.x
+  #import <FirebaseStorage/FirebaseStorage.h>
+#else
+  // Firebase 9.0+
+  #import <FirebaseStorage/FirebaseStorage-Swift.h>
+#endif
 #import <SDWebImage/SDWebImage.h>
 
 /**

--- a/FirebaseStorageUI/Sources/Public/FirebaseStorageUI/NSURL+FirebaseStorage.h
+++ b/FirebaseStorageUI/Sources/Public/FirebaseStorageUI/NSURL+FirebaseStorage.h
@@ -14,7 +14,14 @@
 //  limitations under the License.
 //
 #import <Foundation/Foundation.h>
-#import <FirebaseStorage/FirebaseStorage.h>
+
+#if __has_include(<FirebaseStorage/FirebaseStorage.h>)
+  // Firebase 8.x
+  #import <FirebaseStorage/FirebaseStorage.h>
+#else
+  // Firebase 9.0+
+  #import <FirebaseStorage/FirebaseStorage-Swift.h>
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FirebaseStorageUI/Sources/Public/FirebaseStorageUI/UIImageView+FirebaseStorage.h
+++ b/FirebaseStorageUI/Sources/Public/FirebaseStorageUI/UIImageView+FirebaseStorage.h
@@ -16,7 +16,13 @@
 
 #import <UIKit/UIKit.h>
 
-#import <FirebaseStorage/FirebaseStorage.h>
+#if __has_include(<FirebaseStorage/FirebaseStorage.h>)
+  // Firebase 8.x
+  #import <FirebaseStorage/FirebaseStorage.h>
+#else
+  // Firebase 9.0+
+  #import <FirebaseStorage/FirebaseStorage-Swift.h>
+#endif
 #import <SDWebImage/SDWebImage.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/FirebaseUI.podspec
+++ b/FirebaseUI.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseUI'
-  s.version      = '12.1.1'
+  s.version      = '12.2.0'
   s.summary      = 'UI binding libraries for Firebase.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }
-  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'v' + s.version.to_s}
+  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'pre' + s.version.to_s}
   s.author       = 'Firebase'
   s.platform = :ios
   s.ios.deployment_target = '10.0'

--- a/FirebaseUI.podspec
+++ b/FirebaseUI.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary      = 'UI binding libraries for Firebase.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }
-  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'pre' + s.version.to_s}
+  s.source       = { :git => 'https://github.com/firebase/FirebaseUI-iOS.git', :tag => 'v' + s.version.to_s}
   s.author       = 'Firebase'
   s.platform = :ios
   s.ios.deployment_target = '10.0'

--- a/Package.swift
+++ b/Package.swift
@@ -72,7 +72,7 @@ let package = Package(
     .package(
       name: "Firebase", 
       url: "https://github.com/firebase/firebase-ios-sdk.git",
-      from: "8.0.0"
+      from: "8.0.0"..<"10.0.0"
     ),
     .package(
       name: "GoogleSignIn",

--- a/Package.swift
+++ b/Package.swift
@@ -72,7 +72,7 @@ let package = Package(
     .package(
       name: "Firebase", 
       url: "https://github.com/firebase/firebase-ios-sdk.git",
-      from: "8.0.0"..<"10.0.0"
+      "8.0.0"..<"10.0.0"
     ),
     .package(
       name: "GoogleSignIn",

--- a/samples/objc/FirebaseUI-demo-objc/FUIAppDelegate.m
+++ b/samples/objc/FirebaseUI-demo-objc/FUIAppDelegate.m
@@ -16,8 +16,9 @@
 
 #import "FUIAppDelegate.h"
 
-@import Firebase;
+@import FirebaseCore;
 @import FirebaseAuthUI;
+@import FirebaseDynamicLinks;
 @import FBSDKCoreKit;
 #import <GTMSessionFetcher/GTMSessionFetcherLogging.h>
 


### PR DESCRIPTION
podspec and source updates to support both Firebase 8.x and 9.x

It uses `pre` prefixed tags for testing on SpecsStaging.