### PR TITLE
Update Facebook SDK to ..<"17.0.0" in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -67,7 +67,7 @@ let package = Package(
     .package(
       name: "Facebook", 
       url: "https://github.com/facebook/facebook-ios-sdk.git",
-      "11.0.0"..<"16.0.0"
+      "11.0.0"..<"17.0.0"
     ),
     .package(
       name: "Firebase", 


### PR DESCRIPTION
Only CocoaPods was updated to `< 17.0` in https://github.com/firebase/FirebaseUI-iOS/pull/1162
We'd appreciate a release v13.1.1 with this fix.