### PR TITLE
Fix AuthUI build with Firebase 11

### DIFF
--- a/FirebaseAnonymousAuthUI.podspec
+++ b/FirebaseAnonymousAuthUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseAnonymousAuthUI'
-  s.version      = '14.0.0'
+  s.version      = '14.1.0'
   s.summary      = 'Provides anonymous auth support for FirebaseAuthUI.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }

--- a/FirebaseAuthUI.podspec
+++ b/FirebaseAuthUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseAuthUI'
-  s.version      = '14.0.0'
+  s.version      = '14.1.0'
   s.summary      = 'A prebuilt authentication UI flow for Firebase Auth.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }

--- a/FirebaseAuthUI/Sources/FUIAccountSettingsOperationDeleteAccount.m
+++ b/FirebaseAuthUI/Sources/FUIAccountSettingsOperationDeleteAccount.m
@@ -19,6 +19,8 @@
 #import "FirebaseAuthUI/Sources/FUIAccountSettingsOperation_Internal.h"
 #import "FirebaseAuthUI/Sources/FUIAccountSettingsOperationForgotPassword.h"
 
+@import FirebaseAuth;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @implementation FUIAccountSettingsOperationDeleteAccount

--- a/FirebaseAuthUI/Sources/FUIAccountSettingsOperationForgotPassword.m
+++ b/FirebaseAuthUI/Sources/FUIAccountSettingsOperationForgotPassword.m
@@ -19,6 +19,8 @@
 #import "FirebaseAuthUI/Sources/FUIAccountSettingsOperation_Internal.h"
 #import "FirebaseAuthUI/Sources/Public/FirebaseAuthUI/FUIAuthBaseViewController_Internal.h"
 
+@import FirebaseAuth;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @implementation FUIAccountSettingsOperationForgotPassword

--- a/FirebaseAuthUI/Sources/FUIAccountSettingsOperationUnlinkAccount.m
+++ b/FirebaseAuthUI/Sources/FUIAccountSettingsOperationUnlinkAccount.m
@@ -19,6 +19,8 @@
 #import "FirebaseAuthUI/Sources/FUIAccountSettingsOperation_Internal.h"
 #import "FirebaseAuthUI/Sources/Public/FirebaseAuthUI/FUIAuthBaseViewController_Internal.h"
 
+@import FirebaseAuth;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface FUIAccountSettingsOperationUnlinkAccount ()

--- a/FirebaseAuthUI/Sources/FUIAccountSettingsOperationUpdateEmail.m
+++ b/FirebaseAuthUI/Sources/FUIAccountSettingsOperationUpdateEmail.m
@@ -19,6 +19,8 @@
 #import "FirebaseAuthUI/Sources/FUIAccountSettingsOperation_Internal.h"
 #import "FirebaseAuthUI/Sources/Public/FirebaseAuthUI/FUIAuthBaseViewController_Internal.h"
 
+@import FirebaseAuth;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @implementation FUIAccountSettingsOperationUpdateEmail

--- a/FirebaseAuthUI/Sources/FUIAccountSettingsOperationUpdateName.m
+++ b/FirebaseAuthUI/Sources/FUIAccountSettingsOperationUpdateName.m
@@ -18,6 +18,8 @@
 
 #import "FirebaseAuthUI/Sources/FUIAccountSettingsOperation_Internal.h"
 
+@import FirebaseAuth;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @implementation FUIAccountSettingsOperationUpdateName

--- a/FirebaseAuthUI/Sources/FUIAccountSettingsOperationUpdatePassword.m
+++ b/FirebaseAuthUI/Sources/FUIAccountSettingsOperationUpdatePassword.m
@@ -18,6 +18,8 @@
 
 #import "FirebaseAuthUI/Sources/FUIAccountSettingsOperation_Internal.h"
 
+@import FirebaseAuth;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface FUIAccountSettingsOperationUpdatePassword ()

--- a/FirebaseAuthUI/Sources/FUIAccountSettingsOperation_Internal.h
+++ b/FirebaseAuthUI/Sources/FUIAccountSettingsOperation_Internal.h
@@ -16,7 +16,7 @@
 
 #import "FirebaseAuthUI/Sources/FUIAccountSettingsOperation.h"
 
-#import <FirebaseAuth/FirebaseAuth.h>
+@import FirebaseAuth;
 
 #import "FirebaseAuthUI/Sources/Public/FirebaseAuthUI/FUIAccountSettingsOperationType.h"
 #import "FirebaseAuthUI/Sources/Public/FirebaseAuthUI/FUIAuthStrings.h"

--- a/FirebaseAuthUI/Sources/FUIAccountSettingsViewController.m
+++ b/FirebaseAuthUI/Sources/FUIAccountSettingsViewController.m
@@ -16,7 +16,7 @@
 
 #import "FirebaseAuthUI/Sources/Public/FirebaseAuthUI/FUIAccountSettingsViewController.h"
 
-#import <FirebaseAuth/FirebaseAuth.h>
+@import FirebaseAuth;
 
 #import "FirebaseAuthUI/Sources/FUIAccountSettingsOperation.h"
 #import "FirebaseAuthUI/Sources/FUIAccountSettingsOperationDeleteAccount.h"

--- a/FirebaseAuthUI/Sources/FUIAuth.m
+++ b/FirebaseAuthUI/Sources/FUIAuth.m
@@ -20,13 +20,13 @@
 
 #import <FirebaseCore/FIRApp.h>
 #import <FirebaseCore/FIROptions.h>
-#import <FirebaseAuth/FIRAuth.h>
-#import <FirebaseAuth/FirebaseAuth.h>
 #import "FirebaseAuthUI/Sources/Public/FirebaseAuthUI/FUIAuthBaseViewController_Internal.h"
 #import "FirebaseAuthUI/Sources/Public/FirebaseAuthUI/FUIAuthErrors.h"
 #import "FirebaseAuthUI/Sources/Public/FirebaseAuthUI/FUIAuthErrorUtils.h"
 #import "FirebaseAuthUI/Sources/Public/FirebaseAuthUI/FUIAuthPickerViewController.h"
 #import "FirebaseAuthUI/Sources/Public/FirebaseAuthUI/FUIAuthStrings.h"
+
+@import FirebaseAuth;
 
 /** @var kAppNameCodingKey
     @brief The key used to encode the app Name for NSCoding.

--- a/FirebaseDatabaseUI.podspec
+++ b/FirebaseDatabaseUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseDatabaseUI'
-  s.version      = '14.0.0'
+  s.version      = '14.1.0'
   s.summary      = 'Prebuilt data sources and UI bindings for Firebase Database.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }

--- a/FirebaseEmailAuthUI.podspec
+++ b/FirebaseEmailAuthUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseEmailAuthUI'
-  s.version      = '14.0.0'
+  s.version      = '14.1.0'
   s.summary      = 'An email authentication provider for FirebaseAuthUI.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }

--- a/FirebaseFacebookAuthUI.podspec
+++ b/FirebaseFacebookAuthUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseFacebookAuthUI'
-  s.version      = '14.0.0'
+  s.version      = '14.1.0'
   s.summary      = 'A Facebook auth provider for FirebaseAuthUI.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }

--- a/FirebaseFirestoreUI.podspec
+++ b/FirebaseFirestoreUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseFirestoreUI'
-  s.version      = '14.0.0'
+  s.version      = '14.1.0'
   s.summary      = 'Data libraries and UI bindings for Firestore.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }

--- a/FirebaseGoogleAuthUI.podspec
+++ b/FirebaseGoogleAuthUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseGoogleAuthUI'
-  s.version      = '14.0.0'
+  s.version      = '14.1.0'
   s.summary      = 'Google authentication for FirebaseAuthUI.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }

--- a/FirebaseOAuthUI.podspec
+++ b/FirebaseOAuthUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseOAuthUI'
-  s.version      = '14.0.0'
+  s.version      = '14.1.0'
   s.summary      = 'A collection of OAuth providers for FirebaseAuthUI.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }

--- a/FirebasePhoneAuthUI.podspec
+++ b/FirebasePhoneAuthUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebasePhoneAuthUI'
-  s.version      = '14.0.0'
+  s.version      = '14.1.0'
   s.summary      = 'A phone auth provider for FirebaseAuthUI.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }

--- a/FirebaseStorageUI.podspec
+++ b/FirebaseStorageUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseStorageUI'
-  s.version      = '14.0.0'
+  s.version      = '14.1.0'
   s.summary      = 'UI binding libraries for Firebase.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }

--- a/FirebaseUI.podspec
+++ b/FirebaseUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseUI'
-  s.version      = '14.0.0'
+  s.version      = '14.1.0'
   s.summary      = 'UI binding libraries for Firebase.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }


### PR DESCRIPTION
With Firebase 11, Objective C sources that reference FirebaseAuth types need to do module imports.