### PR TITLE
More Firebase 11 updates

### DIFF
--- a/FirebaseAnonymousAuthUI.podspec
+++ b/FirebaseAnonymousAuthUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseAnonymousAuthUI'
-  s.version      = '14.1.0'
+  s.version      = '14.2.0'
   s.summary      = 'Provides anonymous auth support for FirebaseAuthUI.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }

--- a/FirebaseAnonymousAuthUI/FirebaseAnonymousAuthUITests/FirebaseAnonymousAuthUITests.m
+++ b/FirebaseAnonymousAuthUI/FirebaseAnonymousAuthUITests/FirebaseAnonymousAuthUITests.m
@@ -17,7 +17,7 @@
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 
-#import <FirebaseAuth/FirebaseAuth.h>
+@import FirebaseAuth;
 #import <FirebaseAuthUI/FirebaseAuthUI.h>
 
 #import "FUIAnonymousAuth.h"

--- a/FirebaseAnonymousAuthUI/Sources/FUIAnonymousAuth.m
+++ b/FirebaseAnonymousAuthUI/Sources/FUIAnonymousAuth.m
@@ -14,6 +14,8 @@
 //  limitations under the License.
 //
 
+@import FirebaseAuth;
+
 #import <FirebaseAuthUI/FirebaseAuthUI.h>
 
 #import "FirebaseAnonymousAuthUI/Sources/Public/FirebaseAnonymousAuthUI/FUIAnonymousAuth.h"

--- a/FirebaseAuthUI.podspec
+++ b/FirebaseAuthUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseAuthUI'
-  s.version      = '14.1.0'
+  s.version      = '14.2.0'
   s.summary      = 'A prebuilt authentication UI flow for Firebase Auth.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }

--- a/FirebaseAuthUI/Sources/FUIAccountSettingsOperation.m
+++ b/FirebaseAuthUI/Sources/FUIAccountSettingsOperation.m
@@ -230,7 +230,7 @@ NS_ASSUME_NONNULL_BEGIN
                                   alertMessage:message
                               alertCloseButton:FUILocalizedString(kStr_Cancel)
                                providerHandler:^(id<FIRUserInfo> provider) {
-    if (![provider.providerID isEqualToString:FIREmailAuthProviderID]) {
+    if (![provider.providerID isEqualToString:@"email"]) {
       [self reauthenticateWithProvider:provider.providerID actionHandler:handler];
     } else {
       [self showVerifyPasswordViewWithMessage:message providerHandler:handler];

--- a/FirebaseAuthUI/Sources/FUIAccountSettingsOperationDeleteAccount.m
+++ b/FirebaseAuthUI/Sources/FUIAccountSettingsOperationDeleteAccount.m
@@ -43,7 +43,8 @@ NS_ASSUME_NONNULL_BEGIN
                                   alertMessage:FUILocalizedString(kStr_DeleteAccountBody)
                               alertCloseButton:FUILocalizedString(kStr_Cancel)
                                providerHandler:^(id<FIRUserInfo> provider) {
-    if (![provider.providerID isEqualToString:FIREmailAuthProviderID]) {
+    // TODO: Use public API after Firebase 11 minimum.
+    if (![provider.providerID isEqualToString:@"email"]) {
       [self reauthenticateWithProvider:provider.providerID actionHandler:^{
         [self showDeleteAccountView];
       }];

--- a/FirebaseAuthUI/Sources/FUIAccountSettingsViewController.m
+++ b/FirebaseAuthUI/Sources/FUIAccountSettingsViewController.m
@@ -79,11 +79,11 @@ static NSString *const kUserAccountImage = @"ic_account_circle.png";
 
   for (id<FIRUserInfo> userInfo in providers) {
     if (userInfo.email.length > 0 &&
-        ![userInfo.providerID isEqualToString:FIREmailAuthProviderID]) {
+        ![userInfo.providerID isEqualToString:@"email"]) {
       hasEmailInLinkedProvider = YES;
     }
 
-    if ([userInfo.providerID isEqualToString:FIREmailAuthProviderID]) {
+    if ([userInfo.providerID isEqualToString:@"email"]) {
       hasPasswordProvider = YES;
     }
   }
@@ -225,7 +225,7 @@ static NSString *const kUserAccountImage = @"ic_account_circle.png";
   NSMutableArray *linkedAccounts =
       [[NSMutableArray alloc] initWithCapacity:self.auth.currentUser.providerData.count];
   for (id<FIRUserInfo> userInfo in self.auth.currentUser.providerData) {
-    if ([userInfo.providerID isEqualToString:FIREmailAuthProviderID]) {
+    if ([userInfo.providerID isEqualToString:@"email"]) {
       continue;
     }
     FUIStaticContentTableViewCell *cell =
@@ -262,7 +262,7 @@ static NSString *const kUserAccountImage = @"ic_account_circle.png";
   NSMutableArray *linkedAccounts =
       [[NSMutableArray alloc] initWithCapacity:self.auth.currentUser.providerData.count];
   for (id<FIRUserInfo> userInfo in self.auth.currentUser.providerData) {
-    if ([userInfo.providerID isEqualToString:FIREmailAuthProviderID]) {
+    if ([userInfo.providerID isEqualToString:@"email"]) {
       continue;
     }
     FUIStaticContentTableViewCell *cell =
@@ -309,7 +309,7 @@ static NSString *const kUserAccountImage = @"ic_account_circle.png";
   NSMutableArray *linkedAccounts =
       [[NSMutableArray alloc] initWithCapacity:self.auth.currentUser.providerData.count];
   for (id<FIRUserInfo> userInfo in self.auth.currentUser.providerData) {
-    if ([userInfo.providerID isEqualToString:FIREmailAuthProviderID]) {
+    if ([userInfo.providerID isEqualToString:@"email"]) {
       continue;
     }
     FUIStaticContentTableViewCell *cell =

--- a/FirebaseAuthUI/Sources/FUIAuth.m
+++ b/FirebaseAuthUI/Sources/FUIAuth.m
@@ -238,7 +238,10 @@ static NSString *const kFirebaseAuthUIFrameworkMarker = @"FirebaseUI-iOS";
     if (error) {
       // Check for "credential in use" conflict error and handle appropriately.
       if (error.code == FIRAuthErrorCodeCredentialAlreadyInUse) {
-        FIRAuthCredential *newCredential = error.userInfo[FIRAuthErrorUserInfoUpdatedCredentialKey];
+        // TODO: When Firebase 11 is minimum update string to
+        // FIRAuthErrors.userInfoUpdatedCredentialKey
+        FIRAuthCredential *newCredential =
+          error.userInfo[@"FIRAuthErrorUserInfoUpdatedCredentialKey"];
         NSDictionary *userInfo = @{ };
         if (newCredential) {
           userInfo = @{ FUIAuthCredentialKey : newCredential };

--- a/FirebaseAuthUI/Sources/FUIAuthBaseViewController.m
+++ b/FirebaseAuthUI/Sources/FUIAuthBaseViewController.m
@@ -16,7 +16,7 @@
 
 #import "FirebaseAuthUI/Sources/Public/FirebaseAuthUI/FUIAuthBaseViewController_Internal.h"
 
-#import <FirebaseAuth/FirebaseAuth.h>
+@import FirebaseAuth;
 #import <objc/runtime.h>
 
 #import "FirebaseAuthUI/Sources/Public/FirebaseAuthUI/FUIAuthErrorUtils.h"
@@ -430,13 +430,13 @@ static NSString *const kAuthUICodingKey = @"authUI";
 }
 
 + (NSString *)providerLocalizedName:(NSString *)providerId {
-  if ([providerId isEqualToString:FIREmailAuthProviderID]) {
+  if ([providerId isEqualToString:@"email"]) {
     return FUILocalizedString(kStr_ProviderTitlePassword);
-  } else if ([providerId isEqualToString:FIRGoogleAuthProviderID]) {
+  } else if ([providerId isEqualToString:@"google.com"]) {
     return FUILocalizedString(kStr_ProviderTitleGoogle);
-  } else if ([providerId isEqualToString:FIRFacebookAuthProviderID]) {
+  } else if ([providerId isEqualToString:@"facebook.com"]) {
     return FUILocalizedString(kStr_ProviderTitleFacebook);
-  } else if ([providerId isEqualToString:FIRTwitterAuthProviderID]) {
+  } else if ([providerId isEqualToString:@"twitter.com"]) {
     return FUILocalizedString(kStr_ProviderTitleTwitter);
   }
   return @"";

--- a/FirebaseAuthUI/Sources/FUIAuthPickerViewController.m
+++ b/FirebaseAuthUI/Sources/FUIAuthPickerViewController.m
@@ -17,7 +17,7 @@
 #import "FirebaseAuthUI/Sources/Public/FirebaseAuthUI/FUIAuthPickerViewController.h"
 
 #import <AuthenticationServices/AuthenticationServices.h>
-#import <FirebaseAuth/FirebaseAuth.h>
+@import FirebaseAuth;
 
 #import "FirebaseAuthUI/Sources/Public/FirebaseAuthUI/FUIAuthBaseViewController_Internal.h"
 #import "FirebaseAuthUI/Sources/FUIAuthSignInButton.h"

--- a/FirebaseAuthUI/Sources/FUIPrivacyAndTermsOfServiceView.m
+++ b/FirebaseAuthUI/Sources/FUIPrivacyAndTermsOfServiceView.m
@@ -16,7 +16,7 @@
 
 #import "FirebaseAuthUI/Sources/Public/FirebaseAuthUI/FUIPrivacyAndTermsOfServiceView.h"
 
-#import <FirebaseAuth/FirebaseAuth.h>
+@import FirebaseAuth;
 #import "FirebaseAuthUI/Sources/Public/FirebaseAuthUI/FUIAuth.h"
 #import "FirebaseAuthUI/Sources/Public/FirebaseAuthUI/FUIAuthStrings.h"
 

--- a/FirebaseAuthUI/Sources/Public/FirebaseAuthUI/FUIAuthProvider.h
+++ b/FirebaseAuthUI/Sources/Public/FirebaseAuthUI/FUIAuthProvider.h
@@ -15,11 +15,13 @@
 //
 
 #import <UIKit/UIKit.h>
-#import <FirebaseAuth/FirebaseAuth.h>
+@import FirebaseAuth;
 
 @class FIRAuth;
 @class FIRAuthCredential;
 @class FIRUserInfo;
+
+typedef void (^FIRAuthResultCallback)(FIRUser *_Nullable user, NSError *_Nullable error);
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FirebaseDatabaseUI.podspec
+++ b/FirebaseDatabaseUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseDatabaseUI'
-  s.version      = '14.1.0'
+  s.version      = '14.2.0'
   s.summary      = 'Prebuilt data sources and UI bindings for Firebase Database.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }

--- a/FirebaseEmailAuthUI.podspec
+++ b/FirebaseEmailAuthUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseEmailAuthUI'
-  s.version      = '14.1.0'
+  s.version      = '14.2.0'
   s.summary      = 'An email authentication provider for FirebaseAuthUI.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }

--- a/FirebaseEmailAuthUI/FirebaseEmailAuthUITests/FirebaseEmailAuthUITests.m
+++ b/FirebaseEmailAuthUI/FirebaseEmailAuthUITests/FirebaseEmailAuthUITests.m
@@ -15,7 +15,7 @@
 //
 
 #import "FUIEmailAuth.h"
-#import <FirebaseAuth/FirebaseAuth.h>
+@import FirebaseAuth;
 #import <FirebaseAuthUI/FUIAuthErrorUtils.h>
 #import "FUIAuthUtils.h"
 #import <FirebaseAuthUI/FUIAuth_Internal.h>

--- a/FirebaseEmailAuthUI/Sources/FUIConfirmEmailViewController.m
+++ b/FirebaseEmailAuthUI/Sources/FUIConfirmEmailViewController.m
@@ -16,7 +16,7 @@
 
 #import "FirebaseEmailAuthUI/Sources/Public/FirebaseEmailAuthUI/FUIConfirmEmailViewController.h"
 
-#import <FirebaseAuth/FirebaseAuth.h>
+@import FirebaseAuth;
 
 #import <FirebaseAuthUI/FirebaseAuthUI.h>
 
@@ -137,7 +137,8 @@ static NSString *const kNextButtonAccessibilityID = @"NextButtonAccessibilityID"
 }
 
 - (void)onNext:(NSString *)emailText {
-  FUIEmailAuth *emailAuth = [self.authUI providerWithID:FIREmailAuthProviderID];
+  // TODO: After Firebase 11 minimum, change to EmailAuthProvider.id.
+  FUIEmailAuth *emailAuth = [self.authUI providerWithID:@"email"];
 
   if (![[self class] isValidEmail:emailText]) {
     [self showAlertWithMessage:FUILocalizedString(kStr_InvalidEmailError)];

--- a/FirebaseEmailAuthUI/Sources/FUIEmailAuth.m
+++ b/FirebaseEmailAuthUI/Sources/FUIEmailAuth.m
@@ -16,9 +16,8 @@
 
 #import "FirebaseEmailAuthUI/Sources/Public/FirebaseEmailAuthUI/FUIEmailAuth.h"
 
-#import <FirebaseCore/FIRApp.h>
-#import <FirebaseCore/FIROptions.h>
-#import <FirebaseAuth/FirebaseAuth.h>
+@import FirebaseCore;
+@import FirebaseAuth;
 #import <GoogleUtilities/GULUserDefaults.h>
 
 #import <FirebaseAuthUI/FirebaseAuthUI.h>
@@ -78,7 +77,7 @@ static NSString *const kEmailLinkSignInLinkingCredentialKey = @"FIRAuthEmailLink
 
 - (instancetype)init {
   return [self initAuthAuthUI:[FUIAuth defaultAuthUI]
-                 signInMethod:FIREmailPasswordAuthSignInMethod
+                 signInMethod:@"email"
               forceSameDevice:NO
         allowNewEmailAccounts:YES
            requireDisplayName:YES
@@ -122,7 +121,7 @@ static NSString *const kEmailLinkSignInLinkingCredentialKey = @"FIRAuthEmailLink
 #pragma mark - FUIAuthProvider
 
 - (nullable NSString *)providerID {
-  return FIREmailAuthProviderID;
+  return @"email";
 }
 
 /** @fn accessToken:
@@ -294,7 +293,7 @@ static NSString *const kEmailLinkSignInLinkingCredentialKey = @"FIRAuthEmailLink
 - (void)handleUnverifiedProviderLinking:(NSString *)providerID
                                   email:(NSString *)email
                                   error:(NSError **)error {
-  if ([providerID isEqualToString:FIRFacebookAuthProviderID]) {
+  if ([providerID isEqualToString:@"facebook.com"]) {
     NSData *unverifiedProviderCredentialData = [GULUserDefaults.standardUserDefaults
                                                 objectForKey:kEmailLinkSignInLinkingCredentialKey];
     FIRAuthCredential *unverifiedProviderCredential;
@@ -533,12 +532,12 @@ static NSString *const kEmailLinkSignInLinkingCredentialKey = @"FIRAuthEmailLink
     NSString *existingFederatedProviderID = [self authProviderFromProviders:providers];
     // Set of providers which can be auto-linked.
     NSSet *supportedProviders =
-        [NSSet setWithObjects:FIRGoogleAuthProviderID,
-                              FIRFacebookAuthProviderID,
-                              FIREmailAuthProviderID,
+        [NSSet setWithObjects:@"google.com",
+                              @"facebook.com",
+                              @"email",
                               nil];
     if ([supportedProviders containsObject:existingFederatedProviderID]) {
-      if ([existingFederatedProviderID isEqualToString:FIREmailAuthProviderID]) {
+      if ([existingFederatedProviderID isEqualToString:@"email"]) {
 
         [FUIAuthBaseViewController showSignInAlertWithEmail:emailHint
                                           providerShortName:@"Email/Password"
@@ -670,7 +669,7 @@ static NSString *const kEmailLinkSignInLinkingCredentialKey = @"FIRAuthEmailLink
       return;
     }
     NSString *bestProviderID = providers[0];
-    if ([bestProviderID isEqual:FIREmailAuthProviderID]) {
+    if ([bestProviderID isEqual:@"email"]) {
       // Password verification.
       UIViewController *passwordController;
       if ([delegate respondsToSelector:
@@ -693,13 +692,14 @@ static NSString *const kEmailLinkSignInLinkingCredentialKey = @"FIRAuthEmailLink
       return;
     }
 
-    if ([bestProviderID isEqual:FIREmailLinkAuthSignInMethod]) {
+    if ([bestProviderID isEqual:@"emailLink"]) {
       NSString *providerName;
-      if ([newCredential.provider isEqualToString:FIRFacebookAuthProviderID]) {
+      if ([newCredential.provider isEqualToString:@"facebook.com"]) {
         providerName = @"Facebook";
-      } else if ([newCredential.provider isEqualToString:FIRTwitterAuthProviderID]) {
+      } else if ([newCredential.provider isEqualToString:@"twitter.com"]) {
         providerName = @"Twitter";
-      } else if ([newCredential.provider isEqualToString:FIRGitHubAuthProviderID]) {
+      } else if ([newCredential.provider isEqualToString:@"github.com"
+@"twitter.com"]) {
         providerName = @"Github";
       }
       NSString *message = [NSString stringWithFormat:
@@ -854,9 +854,9 @@ static NSString *const kEmailLinkSignInLinkingCredentialKey = @"FIRAuthEmailLink
 
 - (nullable NSString *)authProviderFromProviders:(NSArray <NSString *> *) providers {
   NSSet *providerSet =
-  [NSSet setWithArray:@[ FIRFacebookAuthProviderID,
-                         FIRGoogleAuthProviderID,
-                         FIREmailAuthProviderID ]];
+  [NSSet setWithArray:@[ @"facebook.com",
+                         @"google.com",
+                         @"email" ]];
   for (NSString *provider in providers) {
     if ( [providerSet containsObject:provider]) {
       return provider;

--- a/FirebaseEmailAuthUI/Sources/FUIEmailEntryViewController.m
+++ b/FirebaseEmailAuthUI/Sources/FUIEmailEntryViewController.m
@@ -16,7 +16,7 @@
 
 #import "FirebaseEmailAuthUI/Sources/Public/FirebaseEmailAuthUI/FUIEmailEntryViewController.h"
 
-#import <FirebaseAuth/FirebaseAuth.h>
+@import FirebaseAuth;
 
 #import <FirebaseAuthUI/FirebaseAuthUI.h>
 
@@ -138,7 +138,7 @@ static NSString *const kNextButtonAccessibilityID = @"NextButtonAccessibilityID"
 }
 
 - (void)onNext:(NSString *)emailText {
-  FUIEmailAuth *emailAuth = [self.authUI providerWithID:FIREmailAuthProviderID];
+  FUIEmailAuth *emailAuth = [self.authUI providerWithID:@"email"];
   id<FUIAuthDelegate> delegate = self.authUI.delegate;
 
   if (![[self class] isValidEmail:emailText]) {
@@ -165,7 +165,7 @@ static NSString *const kNextButtonAccessibilityID = @"NextButtonAccessibilityID"
     }
 
     id<FUIAuthProvider> provider = [self bestProviderFromProviderIDs:providers];
-    if (provider && ![provider.providerID isEqualToString:FIREmailAuthProviderID]) {
+    if (provider && ![provider.providerID isEqualToString:@"email"]) {
       NSString *email = emailText;
       [[self class] showSignInAlertWithEmail:email
                                     provider:provider
@@ -176,7 +176,7 @@ static NSString *const kNextButtonAccessibilityID = @"NextButtonAccessibilityID"
                                cancelHandler:^{
         [self.authUI signOutWithError:nil];
       }];
-    } else if ([providers containsObject:FIREmailAuthProviderID]) {
+    } else if ([providers containsObject:@"email"]) {
       UIViewController *controller;
       if ([delegate respondsToSelector:@selector(passwordSignInViewControllerForAuthUI:email:)]) {
         controller = [delegate passwordSignInViewControllerForAuthUI:self.authUI
@@ -186,7 +186,9 @@ static NSString *const kNextButtonAccessibilityID = @"NextButtonAccessibilityID"
                                                                        email:emailText];
       }
       [self pushViewController:controller];
-    } else if ([emailAuth.signInMethod isEqualToString:FIREmailLinkAuthSignInMethod]) {
+
+      // TODO: Use API to get string when Firebase 11 is the minimum.
+    } else if ([emailAuth.signInMethod isEqualToString:@"emailLink"]) {
       [self sendSignInLinkToEmail:emailText];
     } else {
       if (providers.count) {
@@ -223,7 +225,7 @@ static NSString *const kNextButtonAccessibilityID = @"NextButtonAccessibilityID"
   }
 
   [self incrementActivity];
-  FUIEmailAuth *emailAuth = [self.authUI providerWithID:FIREmailAuthProviderID];
+  FUIEmailAuth *emailAuth = [self.authUI providerWithID:@"email"];
   [emailAuth generateURLParametersAndLocalCache:email linkingProvider:nil];
   [self.auth sendSignInLinkToEmail:email
                 actionCodeSettings:emailAuth.actionCodeSettings

--- a/FirebaseEmailAuthUI/Sources/FUIPasswordRecoveryViewController.m
+++ b/FirebaseEmailAuthUI/Sources/FUIPasswordRecoveryViewController.m
@@ -16,7 +16,8 @@
 
 #import "FirebaseEmailAuthUI/Sources/Public/FirebaseEmailAuthUI/FUIPasswordRecoveryViewController.h"
 
-#import <FirebaseAuth/FirebaseAuth.h>
+@import FirebaseAuth;
+
 #import <FirebaseAuthUI/FirebaseAuthUI.h>
 
 #import "FirebaseEmailAuthUI/Sources/Public/FirebaseEmailAuthUI/FUIEmailAuth.h"

--- a/FirebaseEmailAuthUI/Sources/FUIPasswordSignInViewController.m
+++ b/FirebaseEmailAuthUI/Sources/FUIPasswordSignInViewController.m
@@ -16,12 +16,15 @@
 
 #import "FUIPasswordSignInViewController_Internal.h"
 
-#import <FirebaseAuth/FirebaseAuth.h>
+@import FirebaseAuth;
 #import <FirebaseAuthUI/FirebaseAuthUI.h>
 
 #import "FirebaseEmailAuthUI/Sources/Public/FirebaseEmailAuthUI/FUIEmailAuth.h"
 #import "FirebaseEmailAuthUI/Sources/FUIEmailAuthStrings.h"
 #import "FirebaseEmailAuthUI/Sources/Public/FirebaseEmailAuthUI/FUIPasswordRecoveryViewController.h"
+
+typedef void (^FIRAuthDataResultCallback)(FIRAuthDataResult *_Nullable authResult,
+                                          NSError *_Nullable error);
 
 /** @var kCellReuseIdentifier
     @brief The reuse identifier for table view cell.

--- a/FirebaseEmailAuthUI/Sources/FUIPasswordSignInViewController_Internal.h
+++ b/FirebaseEmailAuthUI/Sources/FUIPasswordSignInViewController_Internal.h
@@ -15,11 +15,14 @@
 //
 
 #import "FirebaseEmailAuthUI/Sources/Public/FirebaseEmailAuthUI/FUIPasswordSignInViewController.h"
-#import <FirebaseAuth/FirebaseAuth.h>
+@import FirebaseAuth;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface FUIPasswordSignInViewController ()
+
+typedef void (^FIRAuthDataResultCallback)(FIRAuthDataResult *_Nullable authResult,
+                                          NSError *_Nullable error);
 
 /** @property onDismissCallback:
     @brief Sets an optional custom callback for FUIPasswordSigInViewController during dismissal. This block is NOT set to nil after use, set to nil after using

--- a/FirebaseEmailAuthUI/Sources/FUIPasswordSignUpViewController.m
+++ b/FirebaseEmailAuthUI/Sources/FUIPasswordSignUpViewController.m
@@ -16,7 +16,7 @@
 
 #import "FirebaseEmailAuthUI/Sources/Public/FirebaseEmailAuthUI/FUIPasswordSignUpViewController.h"
 
-#import <FirebaseAuth/FirebaseAuth.h>
+@import FirebaseAuth;
 #import <FirebaseAuthUI/FirebaseAuthUI.h>
 
 #import "FirebaseEmailAuthUI/Sources/Public/FirebaseEmailAuthUI/FUIEmailAuth.h"

--- a/FirebaseEmailAuthUI/Sources/FUIPasswordVerificationViewController.m
+++ b/FirebaseEmailAuthUI/Sources/FUIPasswordVerificationViewController.m
@@ -16,7 +16,8 @@
 
 #import "FirebaseEmailAuthUI/Sources/Public/FirebaseEmailAuthUI/FUIPasswordVerificationViewController.h"
 
-#import <FirebaseAuth/FirebaseAuth.h>
+@import FirebaseAuth;
+
 #import <FirebaseAuthUI/FirebaseAuthUI.h>
 
 #import "FirebaseEmailAuthUI/Sources/Public/FirebaseEmailAuthUI/FUIEmailAuth.h"

--- a/FirebaseFacebookAuthUI.podspec
+++ b/FirebaseFacebookAuthUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseFacebookAuthUI'
-  s.version      = '14.1.0'
+  s.version      = '14.2.0'
   s.summary      = 'A Facebook auth provider for FirebaseAuthUI.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }

--- a/FirebaseFacebookAuthUI/FirebaseFacebookAuthUITests/FirebaseFacebookAuthUITests.m
+++ b/FirebaseFacebookAuthUI/FirebaseFacebookAuthUITests/FirebaseFacebookAuthUITests.m
@@ -21,7 +21,7 @@
 
 #import "FUIAuthUtils.h"
 #import <FirebaseAuthUI/FirebaseAuthUI.h>
-#import <FirebaseAuth/FirebaseAuth.h>
+@import FirebaseAuth;
 #import <FirebaseCore/FirebaseCore.h>
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #import <FBSDKLoginKit/FBSDKLoginKit.h>

--- a/FirebaseFacebookAuthUI/Sources/FUIFacebookAuth.m
+++ b/FirebaseFacebookAuthUI/Sources/FUIFacebookAuth.m
@@ -17,7 +17,7 @@
 #import "FirebaseFacebookAuthUI/Sources/Public/FirebaseFacebookAuthUI/FUIFacebookAuth.h"
 
 #import <FirebaseAuthUI/FirebaseAuthUI.h>
-#import <FirebaseAuth/FirebaseAuth.h>
+@import FirebaseAuth;
 
 #if SWIFT_PACKAGE
 @import FBSDKCoreKit;
@@ -133,7 +133,7 @@ static NSString *const kFacebookDisplayName = @"FacebookDisplayName";
 #pragma mark - FUIAuthProvider
 
 - (nullable NSString *)providerID {
-  return FIRFacebookAuthProviderID;
+  return @"facebook.com";
 }
 
 /** @fn accessToken:
@@ -313,7 +313,7 @@ static NSString *const kFacebookDisplayName = @"FacebookDisplayName";
   FIRAuthCredential *credential;
   if (idToken) {
     NSString *rawNonce = self.currentNonce;
-    credential = [FIROAuthProvider credentialWithProviderID:FIRFacebookAuthProviderID
+    credential = [FIROAuthProvider credentialWithProviderID:@"facebook.com"
                                                     IDToken:idToken
                                                    rawNonce:rawNonce];
   } else {
@@ -389,7 +389,7 @@ static NSString *const kFacebookDisplayName = @"FacebookDisplayName";
   if (error) {
     NSError *newError =
         [FUIAuthErrorUtils providerErrorWithUnderlyingError:error
-                                                   providerID:FIRFacebookAuthProviderID];
+                                                   providerID:@"facebook.com"];
     [self completeSignInFlowWithAccessToken:nil idToken:nil error:newError];
     return true;
   }

--- a/FirebaseFirestoreUI.podspec
+++ b/FirebaseFirestoreUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseFirestoreUI'
-  s.version      = '14.1.0'
+  s.version      = '14.2.0'
   s.summary      = 'Data libraries and UI bindings for Firestore.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }

--- a/FirebaseGoogleAuthUI.podspec
+++ b/FirebaseGoogleAuthUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseGoogleAuthUI'
-  s.version      = '14.1.0'
+  s.version      = '14.2.0'
   s.summary      = 'Google authentication for FirebaseAuthUI.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }

--- a/FirebaseGoogleAuthUI.podspec
+++ b/FirebaseGoogleAuthUI.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.dependency 'FirebaseAuth'
   s.dependency 'FirebaseCore'
   s.dependency 'FirebaseAuthUI'
-  s.dependency 'GoogleSignIn', '~> 6.0'
+  s.dependency 'GoogleSignIn', '~> 7.0'
   s.resource_bundles = {
     'FirebaseGoogleAuthUI' => ['FirebaseGoogleAuthUI/Sources/{Resources,Strings}/*.{png,lproj}']
   }

--- a/FirebaseGoogleAuthUI/FirebaseGoogleAuthUITests/FirebaseGoogleAuthUITests.m
+++ b/FirebaseGoogleAuthUI/FirebaseGoogleAuthUITests/FirebaseGoogleAuthUITests.m
@@ -80,6 +80,8 @@
   OCMVerify(never(), [self.mockOAuthProvider providerWithProviderID:@"google.com"]);
 }
 
+#ifdef PORT_REST_OF_FILE_TO_GSI_7
+
 - (void)testUseEmulatorCreatesOAuthProvider {
   [self.authUI useEmulatorWithHost:@"host" port:12345];
   FUIGoogleAuth *provider = [[FUIGoogleAuth alloc] initWithAuthUI:self.authUI];
@@ -340,6 +342,7 @@
   //verify that we are using token from server
   OCMVerifyAll(mockAuthentication);
 }
+#endif
 
 - (void)testSignOut {
   id mockSignIn = OCMClassMock([GIDSignIn class]);

--- a/FirebaseGoogleAuthUI/FirebaseGoogleAuthUITests/FirebaseGoogleAuthUITests.m
+++ b/FirebaseGoogleAuthUI/FirebaseGoogleAuthUITests/FirebaseGoogleAuthUITests.m
@@ -14,7 +14,7 @@
 //  limitations under the License.
 //
 
-#import <FirebaseAuth/FirebaseAuth.h>
+@import FirebaseAuth;
 #import <FirebaseAuthUI/FirebaseAuthUI.h>
 #import <GoogleSignIn/GoogleSignIn.h>
 #import <OCMock/OCMock.h>

--- a/FirebaseGoogleAuthUI/Podfile
+++ b/FirebaseGoogleAuthUI/Podfile
@@ -6,6 +6,7 @@ platform :ios, '13.0'
 target 'FirebaseGoogleAuthUI' do
   use_frameworks!
 
+  pod 'FirebaseAuth'
   pod 'GoogleSignIn', '~> 7.0'
   pod 'FirebaseAuthUI', :path => '../'
 

--- a/FirebaseGoogleAuthUI/Podfile
+++ b/FirebaseGoogleAuthUI/Podfile
@@ -6,7 +6,7 @@ platform :ios, '13.0'
 target 'FirebaseGoogleAuthUI' do
   use_frameworks!
 
-  pod 'GoogleSignIn', '~> 6.0'
+  pod 'GoogleSignIn', '~> 7.0'
   pod 'FirebaseAuthUI', :path => '../'
 
   target 'FirebaseGoogleAuthUITests' do

--- a/FirebaseGoogleAuthUI/Podfile.lock
+++ b/FirebaseGoogleAuthUI/Podfile.lock
@@ -1,57 +1,65 @@
 PODS:
-  - AppAuth (1.6.2):
-    - AppAuth/Core (= 1.6.2)
-    - AppAuth/ExternalUserAgent (= 1.6.2)
-  - AppAuth/Core (1.6.2)
-  - AppAuth/ExternalUserAgent (1.6.2):
+  - AppAuth (1.7.5):
+    - AppAuth/Core (= 1.7.5)
+    - AppAuth/ExternalUserAgent (= 1.7.5)
+  - AppAuth/Core (1.7.5)
+  - AppAuth/ExternalUserAgent (1.7.5):
     - AppAuth/Core
-  - FirebaseAppCheckInterop (10.15.0)
-  - FirebaseAuth (10.15.0):
-    - FirebaseAppCheckInterop (~> 10.0)
+  - FirebaseAppCheckInterop (10.29.0)
+  - FirebaseAuth (10.29.0):
+    - FirebaseAppCheckInterop (~> 10.17)
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/Environment (~> 7.8)
     - GTMSessionFetcher/Core (< 4.0, >= 2.1)
     - RecaptchaInterop (~> 100.0)
-  - FirebaseAuthUI (13.1.0):
-    - FirebaseAuth (< 11.0, >= 8.0)
+  - FirebaseAuthUI (14.2.0):
+    - FirebaseAuth (< 12.0, >= 8.0)
     - FirebaseCore
-  - FirebaseCore (10.15.0):
+  - FirebaseCore (10.29.0):
     - FirebaseCoreInternal (~> 10.0)
-    - GoogleUtilities/Environment (~> 7.8)
-    - GoogleUtilities/Logger (~> 7.8)
-  - FirebaseCoreInternal (10.15.0):
+    - GoogleUtilities/Environment (~> 7.12)
+    - GoogleUtilities/Logger (~> 7.12)
+  - FirebaseCoreInternal (10.29.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - GoogleSignIn (6.2.4):
-    - AppAuth (~> 1.5)
-    - GTMAppAuth (~> 1.3)
-    - GTMSessionFetcher/Core (< 3.0, >= 1.1)
-  - GoogleUtilities/AppDelegateSwizzler (7.11.5):
+  - GoogleSignIn (7.1.0):
+    - AppAuth (< 2.0, >= 1.7.3)
+    - GTMAppAuth (< 5.0, >= 4.1.1)
+    - GTMSessionFetcher/Core (~> 3.3)
+  - GoogleUtilities/AppDelegateSwizzler (7.13.3):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.11.5):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Environment (7.13.3):
+    - GoogleUtilities/Privacy
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.11.5):
+  - GoogleUtilities/Logger (7.13.3):
     - GoogleUtilities/Environment
-  - GoogleUtilities/Network (7.11.5):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Network (7.13.3):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
+    - GoogleUtilities/Privacy
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.11.5)"
-  - GoogleUtilities/Reachability (7.11.5):
+  - "GoogleUtilities/NSData+zlib (7.13.3)":
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Privacy (7.13.3)
+  - GoogleUtilities/Reachability (7.13.3):
     - GoogleUtilities/Logger
-  - GTMAppAuth (1.3.1):
-    - AppAuth/Core (~> 1.6)
-    - GTMSessionFetcher/Core (< 3.0, >= 1.5)
-  - GTMSessionFetcher/Core (2.3.0)
-  - OCMock (3.9.1)
-  - PromisesObjC (2.3.1)
+    - GoogleUtilities/Privacy
+  - GTMAppAuth (4.1.1):
+    - AppAuth/Core (~> 1.7)
+    - GTMSessionFetcher/Core (< 4.0, >= 3.3)
+  - GTMSessionFetcher/Core (3.5.0)
+  - OCMock (3.9.4)
+  - PromisesObjC (2.4.0)
   - RecaptchaInterop (100.0.0)
 
 DEPENDENCIES:
+  - FirebaseAuth
   - FirebaseAuthUI (from `../`)
-  - GoogleSignIn (~> 6.0)
+  - GoogleSignIn (~> 7.0)
   - OCMock
 
 SPEC REPOS:
@@ -74,20 +82,20 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  AppAuth: 3bb1d1cd9340bd09f5ed189fb00b1cc28e1e8570
-  FirebaseAppCheckInterop: a8c555b1c2db1d9445e6c3a08a848167ddb7eb51
-  FirebaseAuth: a55ec5f7f8a5b1c2dd750235c1bb419bfb642445
-  FirebaseAuthUI: 9b4de780078d674019a2bfc560bb812f23b45ff1
-  FirebaseCore: 2cec518b43635f96afe7ac3a9c513e47558abd2e
-  FirebaseCoreInternal: 2f4bee5ed00301b5e56da0849268797a2dd31fb4
-  GoogleSignIn: 5651ce3a61e56ca864160e79b484cd9ed3f49b7a
-  GoogleUtilities: 13e2c67ede716b8741c7989e26893d151b2b2084
-  GTMAppAuth: 0ff230db599948a9ad7470ca667337803b3fc4dd
-  GTMSessionFetcher: 3a63d75eecd6aa32c2fc79f578064e1214dfdec2
-  OCMock: 9491e4bec59e0b267d52a9184ff5605995e74be8
-  PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
+  AppAuth: 501c04eda8a8d11f179dbe8637b7a91bb7e5d2fa
+  FirebaseAppCheckInterop: 6a1757cfd4067d8e00fccd14fcc1b8fd78cfac07
+  FirebaseAuth: e2ebfaf9fb4638a1c9a3b0efd17d1b90943987cd
+  FirebaseAuthUI: f03542565fe2e44a8fbb756ffceb17a8506aad43
+  FirebaseCore: 30e9c1cbe3d38f5f5e75f48bfcea87d7c358ec16
+  FirebaseCoreInternal: df84dd300b561c27d5571684f389bf60b0a5c934
+  GoogleSignIn: d4281ab6cf21542b1cfaff85c191f230b399d2db
+  GoogleUtilities: ea963c370a38a8069cc5f7ba4ca849a60b6d7d15
+  GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
+  GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
+  OCMock: 589f2c84dacb1f5aaf6e4cec1f292551fe748e74
+  PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
 
-PODFILE CHECKSUM: 1ec74150315a4827e22c48e93966c1bda47becf1
+PODFILE CHECKSUM: 7d15986472739d38461cce8a3cae1c21c88ae35c
 
-COCOAPODS: 1.13.0
+COCOAPODS: 1.15.2

--- a/FirebaseGoogleAuthUI/Sources/FUIGoogleAuth.m
+++ b/FirebaseGoogleAuthUI/Sources/FUIGoogleAuth.m
@@ -184,8 +184,6 @@ static NSString *const kSignInWithGoogle = @"SignInWithGoogle";
      @"enabling Google Sign-In."];
   }
 
-  GIDConfiguration *config = [[GIDConfiguration alloc] initWithClientID:clientID];
-
   FUIAuthProviderSignInCompletionBlock callback = ^(FIRAuthCredential *_Nullable credential,
                              NSError *_Nullable error,
                              _Nullable FIRAuthResultCallback result,

--- a/FirebaseGoogleAuthUI/Sources/FUIGoogleAuth.m
+++ b/FirebaseGoogleAuthUI/Sources/FUIGoogleAuth.m
@@ -16,7 +16,8 @@
 
 #import "FirebaseGoogleAuthUI/Sources/Public/FirebaseGoogleAuthUI/FUIGoogleAuth.h"
 
-#import <FirebaseAuth/FirebaseAuth.h>
+@import FirebaseAuth;
+
 #import <FirebaseCore/FirebaseCore.h>
 #import <GoogleSignIn/GoogleSignIn.h>
 #import <FirebaseAuthUI/FirebaseAuthUI.h>
@@ -111,21 +112,22 @@ static NSString *const kSignInWithGoogle = @"SignInWithGoogle";
 #pragma mark - FUIAuthProvider
 
 - (nullable NSString *)providerID {
-  return FIRGoogleAuthProviderID;
+  // TODO: Replace with FIRGoogleAuthProvider.id when Firebase 11 is the minimum.
+  return @"google.com";
 }
 
 - (nullable NSString *)accessToken {
   if (self.authUI.isEmulatorEnabled) {
     return nil;
   }
-  return [self googleSignIn].currentUser.authentication.accessToken;
+  return [self googleSignIn].currentUser.accessToken.tokenString;
 }
 
 - (nullable NSString *)idToken {
   if (self.authUI.isEmulatorEnabled) {
     return nil;
   }
-  return [self googleSignIn].currentUser.authentication.idToken;
+  return [self googleSignIn].currentUser.idToken.tokenString;
 }
 
 - (NSString *)shortName {
@@ -193,11 +195,9 @@ static NSString *const kSignInWithGoogle = @"SignInWithGoogle";
     }
   };
 
-  [signIn signInWithConfiguration:config
-         presentingViewController:presentingViewController
-                             hint:defaultValue
-                         callback:^(GIDGoogleUser *user, NSError *error) {
-    [self handleSignInWithUser:user
+  [signIn signInWithPresentingViewController:presentingViewController
+                                        hint:defaultValue completion:^(GIDSignInResult * _Nullable signInResult, NSError * _Nullable error) {
+    [self handleSignInWithUser:signInResult.user
                          error:error
       presentingViewController:presentingViewController
                       callback:callback];
@@ -234,25 +234,6 @@ static NSString *const kSignInWithGoogle = @"SignInWithGoogle";
   }];
 }
 
-- (void)requestScopesWithPresentingViewController:(UIViewController *)presentingViewController
-                                       completion:(FUIAuthProviderSignInCompletionBlock)completion {
-  GIDSignIn *signIn = [self googleSignIn];
-  [signIn addScopes:self.scopes presentingViewController:presentingViewController
-           callback:^(GIDGoogleUser *user, NSError *error) {
-    [self handleSignInWithUser:user
-                         error:error
-      presentingViewController:presentingViewController
-                      callback:^(FIRAuthCredential *credential,
-                                 NSError *error,
-                                 FIRAuthResultCallback result,
-                                 NSDictionary<NSString *,id> *userInfo) {
-      if (completion != nil) {
-        completion(credential, error, result, userInfo);
-      }
-    }];
-  }];
-}
-
 - (void)signOut {
   if (self.authUI.isEmulatorEnabled) {
     return;
@@ -286,7 +267,7 @@ static NSString *const kSignInWithGoogle = @"SignInWithGoogle";
     } else {
       NSError *newError =
           [FUIAuthErrorUtils providerErrorWithUnderlyingError:error
-                                                     providerID:FIRGoogleAuthProviderID];
+                                                     providerID:@"google.com"];
       if (callback) {
         callback(nil, newError, nil, nil);
       }
@@ -298,8 +279,8 @@ static NSString *const kSignInWithGoogle = @"SignInWithGoogle";
       [FUIAuthBaseViewController addActivityIndicator:presentingViewController.view];
   [activityView startAnimating];
   FIRAuthCredential *credential =
-      [FIRGoogleAuthProvider credentialWithIDToken:user.authentication.idToken
-                                       accessToken:user.authentication.accessToken];
+  [FIRGoogleAuthProvider credentialWithIDToken:user.idToken.tokenString
+                                   accessToken:user.accessToken.tokenString];
   FIRAuthResultCallback result = ^(FIRUser *_Nullable user,
                                    NSError *_Nullable error) {
     [activityView stopAnimating];

--- a/FirebaseGoogleAuthUI/Sources/Public/FirebaseGoogleAuthUI/FUIGoogleAuth.h
+++ b/FirebaseGoogleAuthUI/Sources/Public/FirebaseGoogleAuthUI/FUIGoogleAuth.h
@@ -89,12 +89,6 @@ __attribute__((deprecated("Instead use initWithAuthUI:")));
 - (instancetype)initWithScopes:(NSArray <NSString *> *)scopes
 __attribute__((deprecated("Instead use initWithAuthUI:permissions:"))) NS_DESIGNATED_INITIALIZER;
 
-/** @fn requestScopesWithPresentingViewController:completion:
-    @brief Requests the scopes in the `scopes` array.
- */
-- (void)requestScopesWithPresentingViewController:(UIViewController *)presentingViewController
-                                       completion:(FUIAuthProviderSignInCompletionBlock)completion;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseOAuthUI.podspec
+++ b/FirebaseOAuthUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseOAuthUI'
-  s.version      = '14.1.0'
+  s.version      = '14.2.0'
   s.summary      = 'A collection of OAuth providers for FirebaseAuthUI.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }

--- a/FirebaseOAuthUI/FirebaseOAuthUITests/FirebaseOAuthUITests.m
+++ b/FirebaseOAuthUI/FirebaseOAuthUITests/FirebaseOAuthUITests.m
@@ -17,7 +17,7 @@
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 
-#import <FirebaseAuth/FirebaseAuth.h>
+@import FirebaseAuth;
 #import <FirebaseCore/FirebaseCore.h>
 #import <FirebaseAuthUI/FirebaseAuthUI.h>
 

--- a/FirebaseOAuthUI/Sources/FUIOAuth.m
+++ b/FirebaseOAuthUI/Sources/FUIOAuth.m
@@ -14,6 +14,8 @@
 //  limitations under the License.
 //
 
+@import FirebaseAuth;
+
 #import "FirebaseOAuthUI/Sources/Public/FirebaseOAuthUI/FUIOAuth.h"
 
 #import <AuthenticationServices/AuthenticationServices.h>

--- a/FirebasePhoneAuthUI.podspec
+++ b/FirebasePhoneAuthUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebasePhoneAuthUI'
-  s.version      = '14.1.0'
+  s.version      = '14.2.0'
   s.summary      = 'A phone auth provider for FirebaseAuthUI.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }

--- a/FirebasePhoneAuthUI/FirebasePhoneAuthUITests/FirebasePhoneAuthUITests.m
+++ b/FirebasePhoneAuthUI/FirebasePhoneAuthUITests/FirebasePhoneAuthUITests.m
@@ -18,7 +18,7 @@
 
 #import "FUIAuthUtils.h"
 #import <FirebasePhoneAuthUI/FirebasePhoneAuthUI.h>
-#import <FirebaseAuth/FirebaseAuth.h>
+@import FirebaseAuth;
 #import <FirebaseCore/FirebaseCore.h>
 #import <OCMock/OCMock.h>
 #import "FUIAuthUtils.h"

--- a/FirebasePhoneAuthUI/Sources/FUIPhoneAuth.m
+++ b/FirebasePhoneAuthUI/Sources/FUIPhoneAuth.m
@@ -14,6 +14,8 @@
 //  limitations under the License.
 //
 
+@import FirebaseAuth;
+
 #import "FirebasePhoneAuthUI/Sources/FUIPhoneAuth_Internal.h"
 
 #import <FirebaseAuthUI/FirebaseAuthUI.h>

--- a/FirebasePhoneAuthUI/Sources/FUIPhoneEntryViewController.m
+++ b/FirebasePhoneAuthUI/Sources/FUIPhoneEntryViewController.m
@@ -16,9 +16,8 @@
 
 #import "FirebasePhoneAuthUI/Sources/FUIPhoneEntryViewController.h"
 
-#import <FirebaseAuth/FirebaseAuth.h>
-#import <FirebaseAuth/FIRAuthUIDelegate.h>
-#import <FirebaseAuth/FIRPhoneAuthProvider.h>
+@import FirebaseAuth;
+
 #import <FirebaseAuthUI/FirebaseAuthUI.h>
 
 #import "FirebasePhoneAuthUI/Sources/Public/FirebasePhoneAuthUI/FUIPhoneAuth.h"

--- a/FirebasePhoneAuthUI/Sources/FUIPhoneVerificationViewController.m
+++ b/FirebasePhoneAuthUI/Sources/FUIPhoneVerificationViewController.m
@@ -16,8 +16,8 @@
 
 #import "FirebasePhoneAuthUI/Sources/FUIPhoneVerificationViewController.h"
 
-#import <FirebaseAuth/FIRAuthUIDelegate.h>
-#import <FirebaseAuth/FIRPhoneAuthProvider.h>
+@import FirebaseAuth;
+
 #import <FirebaseAuthUI/FirebaseAuthUI.h>
 
 #import "FirebasePhoneAuthUI/Sources/Public/FirebasePhoneAuthUI/FUIPhoneAuth.h"

--- a/FirebaseStorageUI.podspec
+++ b/FirebaseStorageUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseStorageUI'
-  s.version      = '14.1.0'
+  s.version      = '14.2.0'
   s.summary      = 'UI binding libraries for Firebase.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }

--- a/Package.swift
+++ b/Package.swift
@@ -77,12 +77,12 @@ let package = Package(
     .package(
       name: "GoogleSignIn",
       url: "https://github.com/google/GoogleSignIn-iOS",
-      from: "6.0.0"
+      from: "7.0.0"
     ),
     .package(
       name: "GoogleUtilities",
       url: "https://github.com/google/GoogleUtilities.git",
-      from: "7.4.1"
+      "7.4.1"..<"9.0.0"
     ),
     .package(
       name: "SDWebImage",

--- a/UITests/FirebaseUISample/FUIViewController.m
+++ b/UITests/FirebaseUISample/FUIViewController.m
@@ -84,14 +84,16 @@ typedef NS_ENUM(NSUInteger, FIRProviders) {
   NSString *firstProviderID = _authProviders.firstObject.providerID;
   BOOL shouldSkipPhoneAuthPicker = _authProviders.count == 1 &&
       ([firstProviderID isEqualToString:FIRPhoneAuthProviderID] ||
-       [firstProviderID isEqualToString:FIREmailAuthProviderID]);
+       [firstProviderID isEqualToString:@
+@"email"]);
   if (!shouldSkipPhoneAuthPicker) {
     UIViewController *controller = [self.authUIMock authViewController];
     [self presentViewController:controller animated:YES completion:nil];
   } else if ([firstProviderID isEqualToString:FIRPhoneAuthProviderID]) {
     FUIPhoneAuth *provider = _authProviders.firstObject;
     [provider signInWithPresentingViewController:self phoneNumber:nil];
-  } else if ([firstProviderID isEqualToString:FIREmailAuthProviderID]) {
+  } else if ([firstProviderID isEqualToString:@
+@"email"]) {
     FUIEmailAuth *provider = _authProviders.firstObject;
     [provider signInWithPresentingViewController:self email:nil];
   }
@@ -383,7 +385,8 @@ typedef NS_ENUM(NSUInteger, FIRProviders) {
   id emailPasswordProviderMock = [self createPasswordProvider];
 
   //Add third party provider with email
-  id linkedProviderMock = [self createThirdPartyProvider:FIRGoogleAuthProviderID hasEmail:YES];
+  id linkedProviderMock = [self createThirdPartyProvider:@
+@"google.com" hasEmail:YES];
 
   // Stub providerData
   NSArray *providers =
@@ -395,7 +398,8 @@ typedef NS_ENUM(NSUInteger, FIRProviders) {
   id mockUser = [self mockUserWhichHasEmail:YES];
 
   //Add third party provider without email
-  id linkedProviderMock = [self createThirdPartyProvider:FIRGoogleAuthProviderID hasEmail:NO];
+  id linkedProviderMock = [self createThirdPartyProvider:@
+@"google.com" hasEmail:NO];
 
   //Add EmailPassword provider
   id emailPasswordProviderMock = [self createPasswordProvider];
@@ -410,7 +414,8 @@ typedef NS_ENUM(NSUInteger, FIRProviders) {
   id mockUser = [self mockUserWhichHasEmail:NO];
 
   //Add third party provider without email
-  id linkedProviderMock = [self createThirdPartyProvider:FIRGoogleAuthProviderID hasEmail:NO];
+  id linkedProviderMock = [self createThirdPartyProvider:@
+@"google.com" hasEmail:NO];
 
   // Stub providerData
   NSArray *providers = [NSArray arrayWithObject:linkedProviderMock];
@@ -421,7 +426,8 @@ typedef NS_ENUM(NSUInteger, FIRProviders) {
   id mockUser = [self mockUserWhichHasEmail:YES];
 
   //Add third party provider with email
-  id linkedProviderMock = [self createThirdPartyProvider:FIRGoogleAuthProviderID hasEmail:YES];
+  id linkedProviderMock = [self createThirdPartyProvider:@
+@"google.com" hasEmail:YES];
 
   // Stub providerData
   NSArray *providers = [NSArray arrayWithObject:linkedProviderMock];
@@ -432,7 +438,8 @@ typedef NS_ENUM(NSUInteger, FIRProviders) {
 
 - (id)createPasswordProvider {
   id emailPasswordProviderMock = OCMProtocolMock(@protocol(FIRUserInfo));
-  OCMStub([emailPasswordProviderMock providerID]).andReturn(FIREmailAuthProviderID);
+  OCMStub([emailPasswordProviderMock providerID]).andReturn(@
+@"email");
   OCMStub([emailPasswordProviderMock email]).andReturn(@"password@email.com");
   OCMStub([emailPasswordProviderMock displayName]).andReturn(@"password displayName");
 
@@ -572,7 +579,8 @@ typedef NS_ENUM(NSUInteger, FIRProviders) {
   [self mockDeleteUserRequest:mockUser];
 
   // mock re-authentication with 3P provider
-  [self mockSignInWithProvider:FIRGoogleAuthProviderID user:mockUser];
+  [self mockSignInWithProvider:@
+@"google.com" user:mockUser];
 
   // mock unlinking 3P provider
   [self mockUnlinkOperation:mockUser];

--- a/samples/objc/FirebaseUI-demo-objc/Samples/Auth/FUIAuthViewController.m
+++ b/samples/objc/FirebaseUI-demo-objc/Samples/Auth/FUIAuthViewController.m
@@ -262,7 +262,8 @@ static NSString *const kFirebasePrivacyPolicy = @"https://firebase.google.com/su
 
     NSString *providerID = self.authUI.providers.firstObject.providerID;
     BOOL isPhoneAuth = [providerID isEqualToString:FIRPhoneAuthProviderID];
-    BOOL isEmailAuth = [providerID isEqualToString:FIREmailAuthProviderID];
+    BOOL isEmailAuth = [providerID isEqualToString:@
+@"email"];
     BOOL shouldSkipAuthPicker = self.authUI.providers.count == 1 && (isPhoneAuth || isEmailAuth);
     if (shouldSkipAuthPicker) {
       if (isPhoneAuth) {

--- a/samples/objc/FirebaseUI-demo-objc/Samples/Chat/FUIChatViewController.m
+++ b/samples/objc/FirebaseUI-demo-objc/Samples/Chat/FUIChatViewController.m
@@ -15,7 +15,7 @@
 //
 
 @import FirebaseDatabaseUI;
-#import <FirebaseAuth/FirebaseAuth.h>
+@import FirebaseAuth;
 
 #import "FUIChatViewController.h"
 #import "FUIChatMessage.h"

--- a/samples/swift/Podfile.lock
+++ b/samples/swift/Podfile.lock
@@ -1,110 +1,156 @@
 PODS:
-  - abseil/algorithm (1.20220623.0):
-    - abseil/algorithm/algorithm (= 1.20220623.0)
-    - abseil/algorithm/container (= 1.20220623.0)
-  - abseil/algorithm/algorithm (1.20220623.0):
+  - abseil/algorithm (1.20240116.2):
+    - abseil/algorithm/algorithm (= 1.20240116.2)
+    - abseil/algorithm/container (= 1.20240116.2)
+  - abseil/algorithm/algorithm (1.20240116.2):
     - abseil/base/config
-  - abseil/algorithm/container (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/algorithm/container (1.20240116.2):
     - abseil/algorithm/algorithm
     - abseil/base/core_headers
+    - abseil/base/nullability
     - abseil/meta/type_traits
-  - abseil/base (1.20220623.0):
-    - abseil/base/atomic_hook (= 1.20220623.0)
-    - abseil/base/base (= 1.20220623.0)
-    - abseil/base/base_internal (= 1.20220623.0)
-    - abseil/base/config (= 1.20220623.0)
-    - abseil/base/core_headers (= 1.20220623.0)
-    - abseil/base/dynamic_annotations (= 1.20220623.0)
-    - abseil/base/endian (= 1.20220623.0)
-    - abseil/base/errno_saver (= 1.20220623.0)
-    - abseil/base/fast_type_id (= 1.20220623.0)
-    - abseil/base/log_severity (= 1.20220623.0)
-    - abseil/base/malloc_internal (= 1.20220623.0)
-    - abseil/base/prefetch (= 1.20220623.0)
-    - abseil/base/pretty_function (= 1.20220623.0)
-    - abseil/base/raw_logging_internal (= 1.20220623.0)
-    - abseil/base/spinlock_wait (= 1.20220623.0)
-    - abseil/base/strerror (= 1.20220623.0)
-    - abseil/base/throw_delegate (= 1.20220623.0)
-  - abseil/base/atomic_hook (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/base (1.20240116.2):
+    - abseil/base/atomic_hook (= 1.20240116.2)
+    - abseil/base/base (= 1.20240116.2)
+    - abseil/base/base_internal (= 1.20240116.2)
+    - abseil/base/config (= 1.20240116.2)
+    - abseil/base/core_headers (= 1.20240116.2)
+    - abseil/base/cycleclock_internal (= 1.20240116.2)
+    - abseil/base/dynamic_annotations (= 1.20240116.2)
+    - abseil/base/endian (= 1.20240116.2)
+    - abseil/base/errno_saver (= 1.20240116.2)
+    - abseil/base/fast_type_id (= 1.20240116.2)
+    - abseil/base/log_severity (= 1.20240116.2)
+    - abseil/base/malloc_internal (= 1.20240116.2)
+    - abseil/base/no_destructor (= 1.20240116.2)
+    - abseil/base/nullability (= 1.20240116.2)
+    - abseil/base/prefetch (= 1.20240116.2)
+    - abseil/base/pretty_function (= 1.20240116.2)
+    - abseil/base/raw_logging_internal (= 1.20240116.2)
+    - abseil/base/spinlock_wait (= 1.20240116.2)
+    - abseil/base/strerror (= 1.20240116.2)
+    - abseil/base/throw_delegate (= 1.20240116.2)
+  - abseil/base/atomic_hook (1.20240116.2):
     - abseil/base/config
     - abseil/base/core_headers
-  - abseil/base/base (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/base/base (1.20240116.2):
     - abseil/base/atomic_hook
     - abseil/base/base_internal
     - abseil/base/config
     - abseil/base/core_headers
+    - abseil/base/cycleclock_internal
     - abseil/base/dynamic_annotations
     - abseil/base/log_severity
+    - abseil/base/nullability
     - abseil/base/raw_logging_internal
     - abseil/base/spinlock_wait
     - abseil/meta/type_traits
-  - abseil/base/base_internal (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/base/base_internal (1.20240116.2):
     - abseil/base/config
     - abseil/meta/type_traits
-  - abseil/base/config (1.20220623.0)
-  - abseil/base/core_headers (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/base/config (1.20240116.2):
+    - abseil/xcprivacy
+  - abseil/base/core_headers (1.20240116.2):
     - abseil/base/config
-  - abseil/base/dynamic_annotations (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/base/cycleclock_internal (1.20240116.2):
+    - abseil/base/base_internal
+    - abseil/base/config
+    - abseil/xcprivacy
+  - abseil/base/dynamic_annotations (1.20240116.2):
     - abseil/base/config
     - abseil/base/core_headers
-  - abseil/base/endian (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/base/endian (1.20240116.2):
     - abseil/base/base
     - abseil/base/config
     - abseil/base/core_headers
-  - abseil/base/errno_saver (1.20220623.0):
+    - abseil/base/nullability
+    - abseil/xcprivacy
+  - abseil/base/errno_saver (1.20240116.2):
     - abseil/base/config
-  - abseil/base/fast_type_id (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/base/fast_type_id (1.20240116.2):
     - abseil/base/config
-  - abseil/base/log_severity (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/base/log_severity (1.20240116.2):
     - abseil/base/config
     - abseil/base/core_headers
-  - abseil/base/malloc_internal (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/base/malloc_internal (1.20240116.2):
     - abseil/base/base
     - abseil/base/base_internal
     - abseil/base/config
     - abseil/base/core_headers
     - abseil/base/dynamic_annotations
     - abseil/base/raw_logging_internal
-  - abseil/base/prefetch (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/base/no_destructor (1.20240116.2):
     - abseil/base/config
-  - abseil/base/pretty_function (1.20220623.0)
-  - abseil/base/raw_logging_internal (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/base/nullability (1.20240116.2):
+    - abseil/base/core_headers
+    - abseil/meta/type_traits
+    - abseil/xcprivacy
+  - abseil/base/prefetch (1.20240116.2):
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/xcprivacy
+  - abseil/base/pretty_function (1.20240116.2):
+    - abseil/xcprivacy
+  - abseil/base/raw_logging_internal (1.20240116.2):
     - abseil/base/atomic_hook
     - abseil/base/config
     - abseil/base/core_headers
     - abseil/base/errno_saver
     - abseil/base/log_severity
-  - abseil/base/spinlock_wait (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/base/spinlock_wait (1.20240116.2):
     - abseil/base/base_internal
     - abseil/base/core_headers
     - abseil/base/errno_saver
-  - abseil/base/strerror (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/base/strerror (1.20240116.2):
     - abseil/base/config
     - abseil/base/core_headers
     - abseil/base/errno_saver
-  - abseil/base/throw_delegate (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/base/throw_delegate (1.20240116.2):
     - abseil/base/config
     - abseil/base/raw_logging_internal
-  - abseil/cleanup/cleanup (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/cleanup/cleanup (1.20240116.2):
     - abseil/base/config
     - abseil/base/core_headers
     - abseil/cleanup/cleanup_internal
-  - abseil/cleanup/cleanup_internal (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/cleanup/cleanup_internal (1.20240116.2):
     - abseil/base/base_internal
     - abseil/base/core_headers
     - abseil/utility/utility
-  - abseil/container/common (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/container/common (1.20240116.2):
     - abseil/meta/type_traits
     - abseil/types/optional
-  - abseil/container/compressed_tuple (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/container/common_policy_traits (1.20240116.2):
+    - abseil/meta/type_traits
+    - abseil/xcprivacy
+  - abseil/container/compressed_tuple (1.20240116.2):
     - abseil/utility/utility
-  - abseil/container/container_memory (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/container/container_memory (1.20240116.2):
     - abseil/base/config
     - abseil/memory/memory
     - abseil/meta/type_traits
     - abseil/utility/utility
-  - abseil/container/fixed_array (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/container/fixed_array (1.20240116.2):
     - abseil/algorithm/algorithm
     - abseil/base/config
     - abseil/base/core_headers
@@ -112,92 +158,159 @@ PODS:
     - abseil/base/throw_delegate
     - abseil/container/compressed_tuple
     - abseil/memory/memory
-  - abseil/container/flat_hash_map (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/container/flat_hash_map (1.20240116.2):
     - abseil/algorithm/container
     - abseil/base/core_headers
     - abseil/container/container_memory
     - abseil/container/hash_function_defaults
     - abseil/container/raw_hash_map
     - abseil/memory/memory
-  - abseil/container/flat_hash_set (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/container/flat_hash_set (1.20240116.2):
     - abseil/algorithm/container
     - abseil/base/core_headers
     - abseil/container/container_memory
     - abseil/container/hash_function_defaults
     - abseil/container/raw_hash_set
     - abseil/memory/memory
-  - abseil/container/hash_function_defaults (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/container/hash_function_defaults (1.20240116.2):
     - abseil/base/config
     - abseil/hash/hash
     - abseil/strings/cord
     - abseil/strings/strings
-  - abseil/container/hash_policy_traits (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/container/hash_policy_traits (1.20240116.2):
+    - abseil/container/common_policy_traits
     - abseil/meta/type_traits
-  - abseil/container/hashtable_debug_hooks (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/container/hashtable_debug_hooks (1.20240116.2):
     - abseil/base/config
-  - abseil/container/hashtablez_sampler (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/container/hashtablez_sampler (1.20240116.2):
     - abseil/base/base
     - abseil/base/config
     - abseil/base/core_headers
+    - abseil/base/raw_logging_internal
     - abseil/debugging/stacktrace
     - abseil/memory/memory
     - abseil/profiling/exponential_biased
     - abseil/profiling/sample_recorder
     - abseil/synchronization/synchronization
+    - abseil/time/time
     - abseil/utility/utility
-  - abseil/container/inlined_vector (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/container/inlined_vector (1.20240116.2):
     - abseil/algorithm/algorithm
     - abseil/base/core_headers
     - abseil/base/throw_delegate
     - abseil/container/inlined_vector_internal
     - abseil/memory/memory
-  - abseil/container/inlined_vector_internal (1.20220623.0):
+    - abseil/meta/type_traits
+    - abseil/xcprivacy
+  - abseil/container/inlined_vector_internal (1.20240116.2):
+    - abseil/base/config
     - abseil/base/core_headers
     - abseil/container/compressed_tuple
     - abseil/memory/memory
     - abseil/meta/type_traits
     - abseil/types/span
-  - abseil/container/layout (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/container/layout (1.20240116.2):
     - abseil/base/config
     - abseil/base/core_headers
+    - abseil/debugging/demangle_internal
     - abseil/meta/type_traits
     - abseil/strings/strings
     - abseil/types/span
     - abseil/utility/utility
-  - abseil/container/raw_hash_map (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/container/raw_hash_map (1.20240116.2):
+    - abseil/base/config
+    - abseil/base/core_headers
     - abseil/base/throw_delegate
     - abseil/container/container_memory
     - abseil/container/raw_hash_set
-  - abseil/container/raw_hash_set (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/container/raw_hash_set (1.20240116.2):
     - abseil/base/config
     - abseil/base/core_headers
+    - abseil/base/dynamic_annotations
     - abseil/base/endian
     - abseil/base/prefetch
+    - abseil/base/raw_logging_internal
     - abseil/container/common
     - abseil/container/compressed_tuple
     - abseil/container/container_memory
     - abseil/container/hash_policy_traits
     - abseil/container/hashtable_debug_hooks
     - abseil/container/hashtablez_sampler
+    - abseil/hash/hash
     - abseil/memory/memory
     - abseil/meta/type_traits
     - abseil/numeric/bits
     - abseil/utility/utility
-  - abseil/debugging/debugging_internal (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/crc/cpu_detect (1.20240116.2):
+    - abseil/base/base
+    - abseil/base/config
+    - abseil/xcprivacy
+  - abseil/crc/crc32c (1.20240116.2):
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/base/endian
+    - abseil/base/prefetch
+    - abseil/crc/cpu_detect
+    - abseil/crc/crc_internal
+    - abseil/crc/non_temporal_memcpy
+    - abseil/strings/str_format
+    - abseil/strings/strings
+    - abseil/xcprivacy
+  - abseil/crc/crc_cord_state (1.20240116.2):
+    - abseil/base/config
+    - abseil/crc/crc32c
+    - abseil/numeric/bits
+    - abseil/strings/strings
+    - abseil/xcprivacy
+  - abseil/crc/crc_internal (1.20240116.2):
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/base/endian
+    - abseil/base/prefetch
+    - abseil/base/raw_logging_internal
+    - abseil/crc/cpu_detect
+    - abseil/memory/memory
+    - abseil/numeric/bits
+    - abseil/xcprivacy
+  - abseil/crc/non_temporal_arm_intrinsics (1.20240116.2):
+    - abseil/base/config
+    - abseil/xcprivacy
+  - abseil/crc/non_temporal_memcpy (1.20240116.2):
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/crc/non_temporal_arm_intrinsics
+    - abseil/xcprivacy
+  - abseil/debugging/debugging_internal (1.20240116.2):
     - abseil/base/config
     - abseil/base/core_headers
     - abseil/base/dynamic_annotations
     - abseil/base/errno_saver
     - abseil/base/raw_logging_internal
-  - abseil/debugging/demangle_internal (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/debugging/demangle_internal (1.20240116.2):
     - abseil/base/base
     - abseil/base/config
     - abseil/base/core_headers
-  - abseil/debugging/stacktrace (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/debugging/stacktrace (1.20240116.2):
     - abseil/base/config
     - abseil/base/core_headers
+    - abseil/base/dynamic_annotations
+    - abseil/base/raw_logging_internal
     - abseil/debugging/debugging_internal
-  - abseil/debugging/symbolize (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/debugging/symbolize (1.20240116.2):
     - abseil/base/base
     - abseil/base/config
     - abseil/base/core_headers
@@ -207,26 +320,114 @@ PODS:
     - abseil/debugging/debugging_internal
     - abseil/debugging/demangle_internal
     - abseil/strings/strings
-  - abseil/functional/any_invocable (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/flags/commandlineflag (1.20240116.2):
+    - abseil/base/config
+    - abseil/base/fast_type_id
+    - abseil/flags/commandlineflag_internal
+    - abseil/strings/strings
+    - abseil/types/optional
+    - abseil/xcprivacy
+  - abseil/flags/commandlineflag_internal (1.20240116.2):
+    - abseil/base/config
+    - abseil/base/fast_type_id
+    - abseil/xcprivacy
+  - abseil/flags/config (1.20240116.2):
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/flags/path_util
+    - abseil/flags/program_name
+    - abseil/strings/strings
+    - abseil/synchronization/synchronization
+    - abseil/xcprivacy
+  - abseil/flags/flag (1.20240116.2):
+    - abseil/base/base
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/flags/config
+    - abseil/flags/flag_internal
+    - abseil/flags/reflection
+    - abseil/strings/strings
+    - abseil/xcprivacy
+  - abseil/flags/flag_internal (1.20240116.2):
+    - abseil/base/base
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/base/dynamic_annotations
+    - abseil/flags/commandlineflag
+    - abseil/flags/commandlineflag_internal
+    - abseil/flags/config
+    - abseil/flags/marshalling
+    - abseil/flags/reflection
+    - abseil/memory/memory
+    - abseil/meta/type_traits
+    - abseil/strings/strings
+    - abseil/synchronization/synchronization
+    - abseil/utility/utility
+    - abseil/xcprivacy
+  - abseil/flags/marshalling (1.20240116.2):
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/base/log_severity
+    - abseil/numeric/int128
+    - abseil/strings/str_format
+    - abseil/strings/strings
+    - abseil/types/optional
+    - abseil/xcprivacy
+  - abseil/flags/path_util (1.20240116.2):
+    - abseil/base/config
+    - abseil/strings/strings
+    - abseil/xcprivacy
+  - abseil/flags/private_handle_accessor (1.20240116.2):
+    - abseil/base/config
+    - abseil/flags/commandlineflag
+    - abseil/flags/commandlineflag_internal
+    - abseil/strings/strings
+    - abseil/xcprivacy
+  - abseil/flags/program_name (1.20240116.2):
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/flags/path_util
+    - abseil/strings/strings
+    - abseil/synchronization/synchronization
+    - abseil/xcprivacy
+  - abseil/flags/reflection (1.20240116.2):
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/base/no_destructor
+    - abseil/container/flat_hash_map
+    - abseil/flags/commandlineflag
+    - abseil/flags/commandlineflag_internal
+    - abseil/flags/config
+    - abseil/flags/private_handle_accessor
+    - abseil/strings/strings
+    - abseil/synchronization/synchronization
+    - abseil/xcprivacy
+  - abseil/functional/any_invocable (1.20240116.2):
     - abseil/base/base_internal
     - abseil/base/config
     - abseil/base/core_headers
     - abseil/meta/type_traits
     - abseil/utility/utility
-  - abseil/functional/bind_front (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/functional/bind_front (1.20240116.2):
     - abseil/base/base_internal
     - abseil/container/compressed_tuple
     - abseil/meta/type_traits
     - abseil/utility/utility
-  - abseil/functional/function_ref (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/functional/function_ref (1.20240116.2):
     - abseil/base/base_internal
     - abseil/base/core_headers
+    - abseil/functional/any_invocable
     - abseil/meta/type_traits
-  - abseil/hash/city (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/hash/city (1.20240116.2):
     - abseil/base/config
     - abseil/base/core_headers
     - abseil/base/endian
-  - abseil/hash/hash (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/hash/hash (1.20240116.2):
     - abseil/base/config
     - abseil/base/core_headers
     - abseil/base/endian
@@ -235,43 +436,62 @@ PODS:
     - abseil/hash/city
     - abseil/hash/low_level_hash
     - abseil/meta/type_traits
+    - abseil/numeric/bits
     - abseil/numeric/int128
     - abseil/strings/strings
     - abseil/types/optional
     - abseil/types/variant
     - abseil/utility/utility
-  - abseil/hash/low_level_hash (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/hash/low_level_hash (1.20240116.2):
     - abseil/base/config
     - abseil/base/endian
-    - abseil/numeric/bits
+    - abseil/base/prefetch
     - abseil/numeric/int128
-  - abseil/memory (1.20220623.0):
-    - abseil/memory/memory (= 1.20220623.0)
-  - abseil/memory/memory (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/memory (1.20240116.2):
+    - abseil/memory/memory (= 1.20240116.2)
+  - abseil/memory/memory (1.20240116.2):
     - abseil/base/core_headers
     - abseil/meta/type_traits
-  - abseil/meta (1.20220623.0):
-    - abseil/meta/type_traits (= 1.20220623.0)
-  - abseil/meta/type_traits (1.20220623.0):
-    - abseil/base/config
-  - abseil/numeric/bits (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/meta (1.20240116.2):
+    - abseil/meta/type_traits (= 1.20240116.2)
+  - abseil/meta/type_traits (1.20240116.2):
     - abseil/base/config
     - abseil/base/core_headers
-  - abseil/numeric/int128 (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/numeric/bits (1.20240116.2):
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/xcprivacy
+  - abseil/numeric/int128 (1.20240116.2):
     - abseil/base/config
     - abseil/base/core_headers
     - abseil/numeric/bits
-  - abseil/numeric/representation (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/numeric/representation (1.20240116.2):
     - abseil/base/config
-  - abseil/profiling/exponential_biased (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/profiling/exponential_biased (1.20240116.2):
     - abseil/base/config
     - abseil/base/core_headers
-  - abseil/profiling/sample_recorder (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/profiling/sample_recorder (1.20240116.2):
     - abseil/base/config
     - abseil/base/core_headers
     - abseil/synchronization/synchronization
     - abseil/time/time
-  - abseil/random/distributions (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/random/bit_gen_ref (1.20240116.2):
+    - abseil/base/core_headers
+    - abseil/base/fast_type_id
+    - abseil/meta/type_traits
+    - abseil/random/internal/distribution_caller
+    - abseil/random/internal/fast_uniform_bits
+    - abseil/random/random
+    - abseil/xcprivacy
+  - abseil/random/distributions (1.20240116.2):
     - abseil/base/base_internal
     - abseil/base/config
     - abseil/base/core_headers
@@ -286,25 +506,31 @@ PODS:
     - abseil/random/internal/uniform_helper
     - abseil/random/internal/wide_multiply
     - abseil/strings/strings
-  - abseil/random/internal/distribution_caller (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/random/internal/distribution_caller (1.20240116.2):
     - abseil/base/config
     - abseil/base/fast_type_id
     - abseil/utility/utility
-  - abseil/random/internal/fast_uniform_bits (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/random/internal/fast_uniform_bits (1.20240116.2):
     - abseil/base/config
     - abseil/meta/type_traits
     - abseil/random/internal/traits
-  - abseil/random/internal/fastmath (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/random/internal/fastmath (1.20240116.2):
     - abseil/numeric/bits
-  - abseil/random/internal/generate_real (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/random/internal/generate_real (1.20240116.2):
     - abseil/meta/type_traits
     - abseil/numeric/bits
     - abseil/random/internal/fastmath
     - abseil/random/internal/traits
-  - abseil/random/internal/iostream_state_saver (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/random/internal/iostream_state_saver (1.20240116.2):
     - abseil/meta/type_traits
     - abseil/numeric/int128
-  - abseil/random/internal/nonsecure_base (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/random/internal/nonsecure_base (1.20240116.2):
     - abseil/base/core_headers
     - abseil/container/inlined_vector
     - abseil/meta/type_traits
@@ -312,16 +538,19 @@ PODS:
     - abseil/random/internal/salted_seed_seq
     - abseil/random/internal/seed_material
     - abseil/types/span
-  - abseil/random/internal/pcg_engine (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/random/internal/pcg_engine (1.20240116.2):
     - abseil/base/config
     - abseil/meta/type_traits
     - abseil/numeric/bits
     - abseil/numeric/int128
     - abseil/random/internal/fastmath
     - abseil/random/internal/iostream_state_saver
-  - abseil/random/internal/platform (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/random/internal/platform (1.20240116.2):
     - abseil/base/config
-  - abseil/random/internal/pool_urbg (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/random/internal/pool_urbg (1.20240116.2):
     - abseil/base/base
     - abseil/base/config
     - abseil/base/core_headers
@@ -332,38 +561,45 @@ PODS:
     - abseil/random/internal/traits
     - abseil/random/seed_gen_exception
     - abseil/types/span
-  - abseil/random/internal/randen (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/random/internal/randen (1.20240116.2):
     - abseil/base/raw_logging_internal
     - abseil/random/internal/platform
     - abseil/random/internal/randen_hwaes
     - abseil/random/internal/randen_slow
-  - abseil/random/internal/randen_engine (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/random/internal/randen_engine (1.20240116.2):
     - abseil/base/endian
     - abseil/meta/type_traits
     - abseil/random/internal/iostream_state_saver
     - abseil/random/internal/randen
-  - abseil/random/internal/randen_hwaes (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/random/internal/randen_hwaes (1.20240116.2):
     - abseil/base/config
     - abseil/random/internal/platform
     - abseil/random/internal/randen_hwaes_impl
-  - abseil/random/internal/randen_hwaes_impl (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/random/internal/randen_hwaes_impl (1.20240116.2):
     - abseil/base/config
     - abseil/base/core_headers
     - abseil/numeric/int128
     - abseil/random/internal/platform
-  - abseil/random/internal/randen_slow (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/random/internal/randen_slow (1.20240116.2):
     - abseil/base/config
     - abseil/base/core_headers
     - abseil/base/endian
     - abseil/numeric/int128
     - abseil/random/internal/platform
-  - abseil/random/internal/salted_seed_seq (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/random/internal/salted_seed_seq (1.20240116.2):
     - abseil/container/inlined_vector
     - abseil/meta/type_traits
     - abseil/random/internal/seed_material
     - abseil/types/optional
     - abseil/types/span
-  - abseil/random/internal/seed_material (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/random/internal/seed_material (1.20240116.2):
     - abseil/base/core_headers
     - abseil/base/dynamic_annotations
     - abseil/base/raw_logging_internal
@@ -371,66 +607,90 @@ PODS:
     - abseil/strings/strings
     - abseil/types/optional
     - abseil/types/span
-  - abseil/random/internal/traits (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/random/internal/traits (1.20240116.2):
     - abseil/base/config
     - abseil/numeric/bits
     - abseil/numeric/int128
-  - abseil/random/internal/uniform_helper (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/random/internal/uniform_helper (1.20240116.2):
     - abseil/base/config
     - abseil/meta/type_traits
     - abseil/numeric/int128
     - abseil/random/internal/traits
-  - abseil/random/internal/wide_multiply (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/random/internal/wide_multiply (1.20240116.2):
     - abseil/base/config
     - abseil/numeric/bits
     - abseil/numeric/int128
     - abseil/random/internal/traits
-  - abseil/random/random (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/random/random (1.20240116.2):
     - abseil/random/distributions
     - abseil/random/internal/nonsecure_base
     - abseil/random/internal/pcg_engine
     - abseil/random/internal/pool_urbg
     - abseil/random/internal/randen_engine
     - abseil/random/seed_sequences
-  - abseil/random/seed_gen_exception (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/random/seed_gen_exception (1.20240116.2):
     - abseil/base/config
-  - abseil/random/seed_sequences (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/random/seed_sequences (1.20240116.2):
     - abseil/base/config
     - abseil/random/internal/pool_urbg
     - abseil/random/internal/salted_seed_seq
     - abseil/random/internal/seed_material
     - abseil/random/seed_gen_exception
     - abseil/types/span
-  - abseil/status/status (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/status/status (1.20240116.2):
     - abseil/base/atomic_hook
+    - abseil/base/config
     - abseil/base/core_headers
+    - abseil/base/no_destructor
+    - abseil/base/nullability
     - abseil/base/raw_logging_internal
     - abseil/base/strerror
     - abseil/container/inlined_vector
     - abseil/debugging/stacktrace
     - abseil/debugging/symbolize
     - abseil/functional/function_ref
+    - abseil/memory/memory
     - abseil/strings/cord
     - abseil/strings/str_format
     - abseil/strings/strings
     - abseil/types/optional
-  - abseil/status/statusor (1.20220623.0):
+    - abseil/types/span
+    - abseil/xcprivacy
+  - abseil/status/statusor (1.20240116.2):
     - abseil/base/base
+    - abseil/base/config
     - abseil/base/core_headers
+    - abseil/base/nullability
     - abseil/base/raw_logging_internal
     - abseil/meta/type_traits
     - abseil/status/status
+    - abseil/strings/has_ostream_operator
+    - abseil/strings/str_format
     - abseil/strings/strings
     - abseil/types/variant
     - abseil/utility/utility
-  - abseil/strings/cord (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/strings/charset (1.20240116.2):
+    - abseil/base/core_headers
+    - abseil/strings/string_view
+    - abseil/xcprivacy
+  - abseil/strings/cord (1.20240116.2):
     - abseil/base/base
     - abseil/base/config
     - abseil/base/core_headers
     - abseil/base/endian
+    - abseil/base/nullability
     - abseil/base/raw_logging_internal
-    - abseil/container/fixed_array
     - abseil/container/inlined_vector
+    - abseil/crc/crc32c
+    - abseil/crc/crc_cord_state
     - abseil/functional/function_ref
     - abseil/meta/type_traits
     - abseil/numeric/bits
@@ -441,11 +701,11 @@ PODS:
     - abseil/strings/cordz_update_scope
     - abseil/strings/cordz_update_tracker
     - abseil/strings/internal
-    - abseil/strings/str_format
     - abseil/strings/strings
     - abseil/types/optional
     - abseil/types/span
-  - abseil/strings/cord_internal (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/strings/cord_internal (1.20240116.2):
     - abseil/base/base_internal
     - abseil/base/config
     - abseil/base/core_headers
@@ -453,23 +713,28 @@ PODS:
     - abseil/base/raw_logging_internal
     - abseil/base/throw_delegate
     - abseil/container/compressed_tuple
+    - abseil/container/container_memory
     - abseil/container/inlined_vector
     - abseil/container/layout
+    - abseil/crc/crc_cord_state
     - abseil/functional/function_ref
     - abseil/meta/type_traits
     - abseil/strings/strings
     - abseil/types/span
-  - abseil/strings/cordz_functions (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/strings/cordz_functions (1.20240116.2):
     - abseil/base/config
     - abseil/base/core_headers
     - abseil/base/raw_logging_internal
     - abseil/profiling/exponential_biased
-  - abseil/strings/cordz_handle (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/strings/cordz_handle (1.20240116.2):
     - abseil/base/base
     - abseil/base/config
     - abseil/base/raw_logging_internal
     - abseil/synchronization/synchronization
-  - abseil/strings/cordz_info (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/strings/cordz_info (1.20240116.2):
     - abseil/base/base
     - abseil/base/config
     - abseil/base/core_headers
@@ -482,29 +747,46 @@ PODS:
     - abseil/strings/cordz_statistics
     - abseil/strings/cordz_update_tracker
     - abseil/synchronization/synchronization
+    - abseil/time/time
     - abseil/types/span
-  - abseil/strings/cordz_statistics (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/strings/cordz_statistics (1.20240116.2):
     - abseil/base/config
     - abseil/strings/cordz_update_tracker
-  - abseil/strings/cordz_update_scope (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/strings/cordz_update_scope (1.20240116.2):
     - abseil/base/config
     - abseil/base/core_headers
     - abseil/strings/cord_internal
     - abseil/strings/cordz_info
     - abseil/strings/cordz_update_tracker
-  - abseil/strings/cordz_update_tracker (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/strings/cordz_update_tracker (1.20240116.2):
     - abseil/base/config
-  - abseil/strings/internal (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/strings/has_ostream_operator (1.20240116.2):
+    - abseil/base/config
+    - abseil/xcprivacy
+  - abseil/strings/internal (1.20240116.2):
     - abseil/base/config
     - abseil/base/core_headers
     - abseil/base/endian
     - abseil/base/raw_logging_internal
     - abseil/meta/type_traits
-  - abseil/strings/str_format (1.20220623.0):
-    - abseil/strings/str_format_internal
-  - abseil/strings/str_format_internal (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/strings/str_format (1.20240116.2):
     - abseil/base/config
     - abseil/base/core_headers
+    - abseil/base/nullability
+    - abseil/strings/str_format_internal
+    - abseil/strings/string_view
+    - abseil/types/span
+    - abseil/xcprivacy
+  - abseil/strings/str_format_internal (1.20240116.2):
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/container/fixed_array
+    - abseil/container/inlined_vector
     - abseil/functional/function_ref
     - abseil/meta/type_traits
     - abseil/numeric/bits
@@ -514,30 +796,46 @@ PODS:
     - abseil/types/optional
     - abseil/types/span
     - abseil/utility/utility
-  - abseil/strings/strings (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/strings/string_view (1.20240116.2):
+    - abseil/base/base
+    - abseil/base/config
+    - abseil/base/core_headers
+    - abseil/base/nullability
+    - abseil/base/throw_delegate
+    - abseil/xcprivacy
+  - abseil/strings/strings (1.20240116.2):
     - abseil/base/base
     - abseil/base/config
     - abseil/base/core_headers
     - abseil/base/endian
+    - abseil/base/nullability
     - abseil/base/raw_logging_internal
     - abseil/base/throw_delegate
     - abseil/memory/memory
     - abseil/meta/type_traits
     - abseil/numeric/bits
     - abseil/numeric/int128
+    - abseil/strings/charset
     - abseil/strings/internal
-  - abseil/synchronization/graphcycles_internal (1.20220623.0):
+    - abseil/strings/string_view
+    - abseil/xcprivacy
+  - abseil/synchronization/graphcycles_internal (1.20240116.2):
     - abseil/base/base
     - abseil/base/base_internal
     - abseil/base/config
     - abseil/base/core_headers
     - abseil/base/malloc_internal
     - abseil/base/raw_logging_internal
-  - abseil/synchronization/kernel_timeout_internal (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/synchronization/kernel_timeout_internal (1.20240116.2):
+    - abseil/base/base
+    - abseil/base/config
     - abseil/base/core_headers
     - abseil/base/raw_logging_internal
     - abseil/time/time
-  - abseil/synchronization/synchronization (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/synchronization/synchronization (1.20240116.2):
     - abseil/base/atomic_hook
     - abseil/base/base
     - abseil/base/base_internal
@@ -551,306 +849,363 @@ PODS:
     - abseil/synchronization/graphcycles_internal
     - abseil/synchronization/kernel_timeout_internal
     - abseil/time/time
-  - abseil/time (1.20220623.0):
-    - abseil/time/internal (= 1.20220623.0)
-    - abseil/time/time (= 1.20220623.0)
-  - abseil/time/internal (1.20220623.0):
-    - abseil/time/internal/cctz (= 1.20220623.0)
-  - abseil/time/internal/cctz (1.20220623.0):
-    - abseil/time/internal/cctz/civil_time (= 1.20220623.0)
-    - abseil/time/internal/cctz/time_zone (= 1.20220623.0)
-  - abseil/time/internal/cctz/civil_time (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/time (1.20240116.2):
+    - abseil/time/internal (= 1.20240116.2)
+    - abseil/time/time (= 1.20240116.2)
+  - abseil/time/internal (1.20240116.2):
+    - abseil/time/internal/cctz (= 1.20240116.2)
+  - abseil/time/internal/cctz (1.20240116.2):
+    - abseil/time/internal/cctz/civil_time (= 1.20240116.2)
+    - abseil/time/internal/cctz/time_zone (= 1.20240116.2)
+  - abseil/time/internal/cctz/civil_time (1.20240116.2):
     - abseil/base/config
-  - abseil/time/internal/cctz/time_zone (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/time/internal/cctz/time_zone (1.20240116.2):
     - abseil/base/config
     - abseil/time/internal/cctz/civil_time
-  - abseil/time/time (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/time/time (1.20240116.2):
     - abseil/base/base
+    - abseil/base/config
     - abseil/base/core_headers
     - abseil/base/raw_logging_internal
     - abseil/numeric/int128
     - abseil/strings/strings
     - abseil/time/internal/cctz/civil_time
     - abseil/time/internal/cctz/time_zone
-  - abseil/types (1.20220623.0):
-    - abseil/types/any (= 1.20220623.0)
-    - abseil/types/bad_any_cast (= 1.20220623.0)
-    - abseil/types/bad_any_cast_impl (= 1.20220623.0)
-    - abseil/types/bad_optional_access (= 1.20220623.0)
-    - abseil/types/bad_variant_access (= 1.20220623.0)
-    - abseil/types/compare (= 1.20220623.0)
-    - abseil/types/optional (= 1.20220623.0)
-    - abseil/types/span (= 1.20220623.0)
-    - abseil/types/variant (= 1.20220623.0)
-  - abseil/types/any (1.20220623.0):
+    - abseil/types/optional
+    - abseil/xcprivacy
+  - abseil/types (1.20240116.2):
+    - abseil/types/any (= 1.20240116.2)
+    - abseil/types/bad_any_cast (= 1.20240116.2)
+    - abseil/types/bad_any_cast_impl (= 1.20240116.2)
+    - abseil/types/bad_optional_access (= 1.20240116.2)
+    - abseil/types/bad_variant_access (= 1.20240116.2)
+    - abseil/types/compare (= 1.20240116.2)
+    - abseil/types/optional (= 1.20240116.2)
+    - abseil/types/span (= 1.20240116.2)
+    - abseil/types/variant (= 1.20240116.2)
+  - abseil/types/any (1.20240116.2):
     - abseil/base/config
     - abseil/base/core_headers
     - abseil/base/fast_type_id
     - abseil/meta/type_traits
     - abseil/types/bad_any_cast
     - abseil/utility/utility
-  - abseil/types/bad_any_cast (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/types/bad_any_cast (1.20240116.2):
     - abseil/base/config
     - abseil/types/bad_any_cast_impl
-  - abseil/types/bad_any_cast_impl (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/types/bad_any_cast_impl (1.20240116.2):
     - abseil/base/config
     - abseil/base/raw_logging_internal
-  - abseil/types/bad_optional_access (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/types/bad_optional_access (1.20240116.2):
     - abseil/base/config
     - abseil/base/raw_logging_internal
-  - abseil/types/bad_variant_access (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/types/bad_variant_access (1.20240116.2):
     - abseil/base/config
     - abseil/base/raw_logging_internal
-  - abseil/types/compare (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/types/compare (1.20240116.2):
+    - abseil/base/config
     - abseil/base/core_headers
     - abseil/meta/type_traits
-  - abseil/types/optional (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/types/optional (1.20240116.2):
     - abseil/base/base_internal
     - abseil/base/config
     - abseil/base/core_headers
+    - abseil/base/nullability
     - abseil/memory/memory
     - abseil/meta/type_traits
     - abseil/types/bad_optional_access
     - abseil/utility/utility
-  - abseil/types/span (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/types/span (1.20240116.2):
     - abseil/algorithm/algorithm
     - abseil/base/core_headers
+    - abseil/base/nullability
     - abseil/base/throw_delegate
     - abseil/meta/type_traits
-  - abseil/types/variant (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/types/variant (1.20240116.2):
     - abseil/base/base_internal
     - abseil/base/config
     - abseil/base/core_headers
     - abseil/meta/type_traits
     - abseil/types/bad_variant_access
     - abseil/utility/utility
-  - abseil/utility/utility (1.20220623.0):
+    - abseil/xcprivacy
+  - abseil/utility/utility (1.20240116.2):
     - abseil/base/base_internal
     - abseil/base/config
     - abseil/meta/type_traits
-  - AppAuth (1.6.2):
-    - AppAuth/Core (= 1.6.2)
-    - AppAuth/ExternalUserAgent (= 1.6.2)
-  - AppAuth/Core (1.6.2)
-  - AppAuth/ExternalUserAgent (1.6.2):
+    - abseil/xcprivacy
+  - abseil/xcprivacy (1.20240116.2)
+  - AppAuth (1.7.5):
+    - AppAuth/Core (= 1.7.5)
+    - AppAuth/ExternalUserAgent (= 1.7.5)
+  - AppAuth/Core (1.7.5)
+  - AppAuth/ExternalUserAgent (1.7.5):
     - AppAuth/Core
-  - BoringSSL-GRPC (0.0.24):
-    - BoringSSL-GRPC/Implementation (= 0.0.24)
-    - BoringSSL-GRPC/Interface (= 0.0.24)
-  - BoringSSL-GRPC/Implementation (0.0.24):
-    - BoringSSL-GRPC/Interface (= 0.0.24)
-  - BoringSSL-GRPC/Interface (0.0.24)
-  - FBAEMKit (16.2.0):
-    - FBSDKCoreKit_Basics (= 16.2.0)
-  - FBSDKCoreKit (16.2.0):
-    - FBAEMKit (= 16.2.0)
-    - FBSDKCoreKit_Basics (= 16.2.0)
-  - FBSDKCoreKit_Basics (16.2.0)
-  - FBSDKLoginKit (16.2.0):
-    - FBSDKCoreKit (= 16.2.0)
-  - FirebaseAnonymousAuthUI (13.1.0):
-    - FirebaseAuth (< 11.0, >= 8.0)
+  - BoringSSL-GRPC (0.0.32):
+    - BoringSSL-GRPC/Implementation (= 0.0.32)
+    - BoringSSL-GRPC/Interface (= 0.0.32)
+  - BoringSSL-GRPC/Implementation (0.0.32):
+    - BoringSSL-GRPC/Interface (= 0.0.32)
+  - BoringSSL-GRPC/Interface (0.0.32)
+  - FBAEMKit (16.3.1):
+    - FBSDKCoreKit_Basics (= 16.3.1)
+  - FBSDKCoreKit (16.3.1):
+    - FBAEMKit (= 16.3.1)
+    - FBSDKCoreKit_Basics (= 16.3.1)
+  - FBSDKCoreKit_Basics (16.3.1)
+  - FBSDKLoginKit (16.3.1):
+    - FBSDKCoreKit (= 16.3.1)
+  - FirebaseAnonymousAuthUI (14.2.0):
+    - FirebaseAuth (< 12.0, >= 8.0)
     - FirebaseAuthUI
     - FirebaseCore
-  - FirebaseAppCheckInterop (10.15.0)
-  - FirebaseAuth (10.15.0):
-    - FirebaseAppCheckInterop (~> 10.0)
+  - FirebaseAppCheckInterop (10.29.0)
+  - FirebaseAuth (10.29.0):
+    - FirebaseAppCheckInterop (~> 10.17)
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/Environment (~> 7.8)
     - GTMSessionFetcher/Core (< 4.0, >= 2.1)
     - RecaptchaInterop (~> 100.0)
-  - FirebaseAuthInterop (10.15.0)
-  - FirebaseAuthUI (13.1.0):
-    - FirebaseAuth (< 11.0, >= 8.0)
+  - FirebaseAuthInterop (10.29.0)
+  - FirebaseAuthUI (14.2.0):
+    - FirebaseAuth (< 12.0, >= 8.0)
     - FirebaseCore
-  - FirebaseCore (10.15.0):
+  - FirebaseCore (10.29.0):
     - FirebaseCoreInternal (~> 10.0)
-    - GoogleUtilities/Environment (~> 7.8)
-    - GoogleUtilities/Logger (~> 7.8)
-  - FirebaseCoreExtension (10.15.0):
+    - GoogleUtilities/Environment (~> 7.12)
+    - GoogleUtilities/Logger (~> 7.12)
+  - FirebaseCoreExtension (10.29.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseCoreInternal (10.15.0):
+  - FirebaseCoreInternal (10.29.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseDatabase (10.15.0):
+  - FirebaseDatabase (10.29.0):
+    - FirebaseAppCheckInterop (~> 10.17)
     - FirebaseCore (~> 10.0)
+    - FirebaseSharedSwift (~> 10.0)
+    - GoogleUtilities/UserDefaults (~> 7.13)
     - leveldb-library (~> 1.22)
-  - FirebaseDatabaseUI (13.1.0):
-    - FirebaseDatabase (< 11.0, >= 8.0)
-  - FirebaseEmailAuthUI (13.1.0):
+  - FirebaseDatabaseUI (14.2.0):
+    - FirebaseDatabase (< 12.0, >= 8.0)
+  - FirebaseEmailAuthUI (14.2.0):
     - FirebaseAuth
     - FirebaseAuthUI
     - FirebaseCore
     - GoogleUtilities/UserDefaults
-  - FirebaseFacebookAuthUI (13.1.0):
+  - FirebaseFacebookAuthUI (14.2.0):
     - FBSDKCoreKit_Basics
     - FBSDKLoginKit (< 17.0, >= 11.0)
     - FirebaseAuth
     - FirebaseAuthUI
     - FirebaseCore
-  - FirebaseFirestore (10.15.0):
-    - abseil/algorithm (~> 1.20220623.0)
-    - abseil/base (~> 1.20220623.0)
-    - abseil/container/flat_hash_map (~> 1.20220623.0)
-    - abseil/memory (~> 1.20220623.0)
-    - abseil/meta (~> 1.20220623.0)
-    - abseil/strings/strings (~> 1.20220623.0)
-    - abseil/time (~> 1.20220623.0)
-    - abseil/types (~> 1.20220623.0)
+  - FirebaseFirestore (10.29.0):
     - FirebaseCore (~> 10.0)
-    - "gRPC-C++ (~> 1.50.1)"
+    - FirebaseCoreExtension (~> 10.0)
+    - FirebaseFirestoreInternal (= 10.29.0)
+    - FirebaseSharedSwift (~> 10.0)
+  - FirebaseFirestoreInternal (10.29.0):
+    - abseil/algorithm (~> 1.20240116.1)
+    - abseil/base (~> 1.20240116.1)
+    - abseil/container/flat_hash_map (~> 1.20240116.1)
+    - abseil/memory (~> 1.20240116.1)
+    - abseil/meta (~> 1.20240116.1)
+    - abseil/strings/strings (~> 1.20240116.1)
+    - abseil/time (~> 1.20240116.1)
+    - abseil/types (~> 1.20240116.1)
+    - FirebaseAppCheckInterop (~> 10.17)
+    - FirebaseCore (~> 10.0)
+    - "gRPC-C++ (~> 1.62.0)"
+    - gRPC-Core (~> 1.62.0)
     - leveldb-library (~> 1.22)
-    - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseFirestoreUI (13.1.0):
-    - FirebaseFirestore (< 11.0, >= 8.0)
-  - FirebaseGoogleAuthUI (13.1.0):
+    - nanopb (< 2.30911.0, >= 2.30908.0)
+  - FirebaseFirestoreUI (14.2.0):
+    - FirebaseFirestore (< 12.0, >= 8.0)
+  - FirebaseGoogleAuthUI (14.2.0):
     - FirebaseAuth
     - FirebaseAuthUI
     - FirebaseCore
-    - GoogleSignIn (~> 6.0)
-  - FirebaseOAuthUI (13.1.0):
-    - FirebaseAuth (< 11.0, >= 8.0)
-    - FirebaseAuthUI (< 14.0, >= 12.0.2)
-  - FirebasePhoneAuthUI (13.1.0):
+    - GoogleSignIn (~> 7.0)
+  - FirebaseOAuthUI (14.2.0):
+    - FirebaseAuth (< 12.0, >= 8.0)
+    - FirebaseAuthUI (< 15.0, >= 12.0.2)
+  - FirebasePhoneAuthUI (14.2.0):
     - FirebaseAuth
     - FirebaseAuthUI
-  - FirebaseStorage (10.15.0):
+  - FirebaseSharedSwift (10.29.0)
+  - FirebaseStorage (10.29.0):
     - FirebaseAppCheckInterop (~> 10.0)
-    - FirebaseAuthInterop (~> 10.0)
+    - FirebaseAuthInterop (~> 10.25)
     - FirebaseCore (~> 10.0)
     - FirebaseCoreExtension (~> 10.0)
+    - GoogleUtilities/Environment (~> 7.12)
     - GTMSessionFetcher/Core (< 4.0, >= 2.1)
-  - FirebaseStorageUI (13.1.0):
-    - FirebaseStorage (< 11.0, >= 8.0)
+  - FirebaseStorageUI (14.2.0):
+    - FirebaseStorage (< 12.0, >= 8.0)
     - SDWebImage (~> 5.6)
-  - FirebaseUI (13.1.0):
-    - FirebaseUI/Anonymous (= 13.1.0)
-    - FirebaseUI/Auth (= 13.1.0)
-    - FirebaseUI/Database (= 13.1.0)
-    - FirebaseUI/Email (= 13.1.0)
-    - FirebaseUI/Facebook (= 13.1.0)
-    - FirebaseUI/Firestore (= 13.1.0)
-    - FirebaseUI/Google (= 13.1.0)
-    - FirebaseUI/OAuth (= 13.1.0)
-    - FirebaseUI/Phone (= 13.1.0)
-    - FirebaseUI/Storage (= 13.1.0)
-  - FirebaseUI/Anonymous (13.1.0):
-    - FirebaseAnonymousAuthUI (~> 13.0)
-  - FirebaseUI/Auth (13.1.0):
-    - FirebaseAuthUI (~> 13.0)
-  - FirebaseUI/Database (13.1.0):
-    - FirebaseDatabaseUI (~> 13.0)
-  - FirebaseUI/Email (13.1.0):
-    - FirebaseEmailAuthUI (~> 13.0)
-  - FirebaseUI/Facebook (13.1.0):
-    - FirebaseFacebookAuthUI (~> 13.0)
-  - FirebaseUI/Firestore (13.1.0):
-    - FirebaseFirestoreUI (~> 13.0)
-  - FirebaseUI/Google (13.1.0):
-    - FirebaseGoogleAuthUI (~> 13.0)
-  - FirebaseUI/OAuth (13.1.0):
-    - FirebaseOAuthUI (~> 13.0)
-  - FirebaseUI/Phone (13.1.0):
-    - FirebasePhoneAuthUI (~> 13.0)
-  - FirebaseUI/Storage (13.1.0):
-    - FirebaseStorageUI (~> 13.0)
-  - GoogleSignIn (6.2.4):
-    - AppAuth (~> 1.5)
-    - GTMAppAuth (~> 1.3)
-    - GTMSessionFetcher/Core (< 3.0, >= 1.1)
-  - GoogleUtilities/AppDelegateSwizzler (7.11.5):
+  - FirebaseUI (14.1.0):
+    - FirebaseUI/Anonymous (= 14.1.0)
+    - FirebaseUI/Auth (= 14.1.0)
+    - FirebaseUI/Database (= 14.1.0)
+    - FirebaseUI/Email (= 14.1.0)
+    - FirebaseUI/Facebook (= 14.1.0)
+    - FirebaseUI/Firestore (= 14.1.0)
+    - FirebaseUI/Google (= 14.1.0)
+    - FirebaseUI/OAuth (= 14.1.0)
+    - FirebaseUI/Phone (= 14.1.0)
+    - FirebaseUI/Storage (= 14.1.0)
+  - FirebaseUI/Anonymous (14.1.0):
+    - FirebaseAnonymousAuthUI (~> 14.0)
+  - FirebaseUI/Auth (14.1.0):
+    - FirebaseAuthUI (~> 14.0)
+  - FirebaseUI/Database (14.1.0):
+    - FirebaseDatabaseUI (~> 14.0)
+  - FirebaseUI/Email (14.1.0):
+    - FirebaseEmailAuthUI (~> 14.0)
+  - FirebaseUI/Facebook (14.1.0):
+    - FirebaseFacebookAuthUI (~> 14.0)
+  - FirebaseUI/Firestore (14.1.0):
+    - FirebaseFirestoreUI (~> 14.0)
+  - FirebaseUI/Google (14.1.0):
+    - FirebaseGoogleAuthUI (~> 14.0)
+  - FirebaseUI/OAuth (14.1.0):
+    - FirebaseOAuthUI (~> 14.0)
+  - FirebaseUI/Phone (14.1.0):
+    - FirebasePhoneAuthUI (~> 14.0)
+  - FirebaseUI/Storage (14.1.0):
+    - FirebaseStorageUI (~> 14.0)
+  - GoogleSignIn (7.1.0):
+    - AppAuth (< 2.0, >= 1.7.3)
+    - GTMAppAuth (< 5.0, >= 4.1.1)
+    - GTMSessionFetcher/Core (~> 3.3)
+  - GoogleUtilities/AppDelegateSwizzler (7.13.3):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.11.5):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Environment (7.13.3):
+    - GoogleUtilities/Privacy
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.11.5):
+  - GoogleUtilities/Logger (7.13.3):
     - GoogleUtilities/Environment
-  - GoogleUtilities/Network (7.11.5):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Network (7.13.3):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
+    - GoogleUtilities/Privacy
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.11.5)"
-  - GoogleUtilities/Reachability (7.11.5):
+  - "GoogleUtilities/NSData+zlib (7.13.3)":
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Privacy (7.13.3)
+  - GoogleUtilities/Reachability (7.13.3):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (7.11.5):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/UserDefaults (7.13.3):
     - GoogleUtilities/Logger
-  - "gRPC-C++ (1.50.1)":
-    - "gRPC-C++/Implementation (= 1.50.1)"
-    - "gRPC-C++/Interface (= 1.50.1)"
-  - "gRPC-C++/Implementation (1.50.1)":
-    - abseil/base/base (= 1.20220623.0)
-    - abseil/base/core_headers (= 1.20220623.0)
-    - abseil/cleanup/cleanup (= 1.20220623.0)
-    - abseil/container/flat_hash_map (= 1.20220623.0)
-    - abseil/container/flat_hash_set (= 1.20220623.0)
-    - abseil/container/inlined_vector (= 1.20220623.0)
-    - abseil/functional/any_invocable (= 1.20220623.0)
-    - abseil/functional/bind_front (= 1.20220623.0)
-    - abseil/functional/function_ref (= 1.20220623.0)
-    - abseil/hash/hash (= 1.20220623.0)
-    - abseil/memory/memory (= 1.20220623.0)
-    - abseil/meta/type_traits (= 1.20220623.0)
-    - abseil/random/random (= 1.20220623.0)
-    - abseil/status/status (= 1.20220623.0)
-    - abseil/status/statusor (= 1.20220623.0)
-    - abseil/strings/cord (= 1.20220623.0)
-    - abseil/strings/str_format (= 1.20220623.0)
-    - abseil/strings/strings (= 1.20220623.0)
-    - abseil/synchronization/synchronization (= 1.20220623.0)
-    - abseil/time/time (= 1.20220623.0)
-    - abseil/types/optional (= 1.20220623.0)
-    - abseil/types/span (= 1.20220623.0)
-    - abseil/types/variant (= 1.20220623.0)
-    - abseil/utility/utility (= 1.20220623.0)
-    - "gRPC-C++/Interface (= 1.50.1)"
-    - gRPC-Core (= 1.50.1)
-  - "gRPC-C++/Interface (1.50.1)"
-  - gRPC-Core (1.50.1):
-    - gRPC-Core/Implementation (= 1.50.1)
-    - gRPC-Core/Interface (= 1.50.1)
-  - gRPC-Core/Implementation (1.50.1):
-    - abseil/base/base (= 1.20220623.0)
-    - abseil/base/core_headers (= 1.20220623.0)
-    - abseil/container/flat_hash_map (= 1.20220623.0)
-    - abseil/container/flat_hash_set (= 1.20220623.0)
-    - abseil/container/inlined_vector (= 1.20220623.0)
-    - abseil/functional/any_invocable (= 1.20220623.0)
-    - abseil/functional/bind_front (= 1.20220623.0)
-    - abseil/functional/function_ref (= 1.20220623.0)
-    - abseil/hash/hash (= 1.20220623.0)
-    - abseil/memory/memory (= 1.20220623.0)
-    - abseil/meta/type_traits (= 1.20220623.0)
-    - abseil/random/random (= 1.20220623.0)
-    - abseil/status/status (= 1.20220623.0)
-    - abseil/status/statusor (= 1.20220623.0)
-    - abseil/strings/cord (= 1.20220623.0)
-    - abseil/strings/str_format (= 1.20220623.0)
-    - abseil/strings/strings (= 1.20220623.0)
-    - abseil/synchronization/synchronization (= 1.20220623.0)
-    - abseil/time/time (= 1.20220623.0)
-    - abseil/types/optional (= 1.20220623.0)
-    - abseil/types/span (= 1.20220623.0)
-    - abseil/types/variant (= 1.20220623.0)
-    - abseil/utility/utility (= 1.20220623.0)
-    - BoringSSL-GRPC (= 0.0.24)
-    - gRPC-Core/Interface (= 1.50.1)
-  - gRPC-Core/Interface (1.50.1)
-  - GTMAppAuth (1.3.1):
-    - AppAuth/Core (~> 1.6)
-    - GTMSessionFetcher/Core (< 3.0, >= 1.5)
-  - GTMSessionFetcher/Core (2.3.0)
-  - leveldb-library (1.22.2)
-  - nanopb (2.30909.0):
-    - nanopb/decode (= 2.30909.0)
-    - nanopb/encode (= 2.30909.0)
-  - nanopb/decode (2.30909.0)
-  - nanopb/encode (2.30909.0)
-  - PromisesObjC (2.3.1)
+    - GoogleUtilities/Privacy
+  - "gRPC-C++ (1.62.5)":
+    - "gRPC-C++/Implementation (= 1.62.5)"
+    - "gRPC-C++/Interface (= 1.62.5)"
+  - "gRPC-C++/Implementation (1.62.5)":
+    - abseil/algorithm/container (~> 1.20240116.2)
+    - abseil/base/base (~> 1.20240116.2)
+    - abseil/base/config (~> 1.20240116.2)
+    - abseil/base/core_headers (~> 1.20240116.2)
+    - abseil/cleanup/cleanup (~> 1.20240116.2)
+    - abseil/container/flat_hash_map (~> 1.20240116.2)
+    - abseil/container/flat_hash_set (~> 1.20240116.2)
+    - abseil/container/inlined_vector (~> 1.20240116.2)
+    - abseil/flags/flag (~> 1.20240116.2)
+    - abseil/flags/marshalling (~> 1.20240116.2)
+    - abseil/functional/any_invocable (~> 1.20240116.2)
+    - abseil/functional/bind_front (~> 1.20240116.2)
+    - abseil/functional/function_ref (~> 1.20240116.2)
+    - abseil/hash/hash (~> 1.20240116.2)
+    - abseil/memory/memory (~> 1.20240116.2)
+    - abseil/meta/type_traits (~> 1.20240116.2)
+    - abseil/random/bit_gen_ref (~> 1.20240116.2)
+    - abseil/random/distributions (~> 1.20240116.2)
+    - abseil/random/random (~> 1.20240116.2)
+    - abseil/status/status (~> 1.20240116.2)
+    - abseil/status/statusor (~> 1.20240116.2)
+    - abseil/strings/cord (~> 1.20240116.2)
+    - abseil/strings/str_format (~> 1.20240116.2)
+    - abseil/strings/strings (~> 1.20240116.2)
+    - abseil/synchronization/synchronization (~> 1.20240116.2)
+    - abseil/time/time (~> 1.20240116.2)
+    - abseil/types/optional (~> 1.20240116.2)
+    - abseil/types/span (~> 1.20240116.2)
+    - abseil/types/variant (~> 1.20240116.2)
+    - abseil/utility/utility (~> 1.20240116.2)
+    - "gRPC-C++/Interface (= 1.62.5)"
+    - "gRPC-C++/Privacy (= 1.62.5)"
+    - gRPC-Core (= 1.62.5)
+  - "gRPC-C++/Interface (1.62.5)"
+  - "gRPC-C++/Privacy (1.62.5)"
+  - gRPC-Core (1.62.5):
+    - gRPC-Core/Implementation (= 1.62.5)
+    - gRPC-Core/Interface (= 1.62.5)
+  - gRPC-Core/Implementation (1.62.5):
+    - abseil/algorithm/container (~> 1.20240116.2)
+    - abseil/base/base (~> 1.20240116.2)
+    - abseil/base/config (~> 1.20240116.2)
+    - abseil/base/core_headers (~> 1.20240116.2)
+    - abseil/cleanup/cleanup (~> 1.20240116.2)
+    - abseil/container/flat_hash_map (~> 1.20240116.2)
+    - abseil/container/flat_hash_set (~> 1.20240116.2)
+    - abseil/container/inlined_vector (~> 1.20240116.2)
+    - abseil/flags/flag (~> 1.20240116.2)
+    - abseil/flags/marshalling (~> 1.20240116.2)
+    - abseil/functional/any_invocable (~> 1.20240116.2)
+    - abseil/functional/bind_front (~> 1.20240116.2)
+    - abseil/functional/function_ref (~> 1.20240116.2)
+    - abseil/hash/hash (~> 1.20240116.2)
+    - abseil/memory/memory (~> 1.20240116.2)
+    - abseil/meta/type_traits (~> 1.20240116.2)
+    - abseil/random/bit_gen_ref (~> 1.20240116.2)
+    - abseil/random/distributions (~> 1.20240116.2)
+    - abseil/random/random (~> 1.20240116.2)
+    - abseil/status/status (~> 1.20240116.2)
+    - abseil/status/statusor (~> 1.20240116.2)
+    - abseil/strings/cord (~> 1.20240116.2)
+    - abseil/strings/str_format (~> 1.20240116.2)
+    - abseil/strings/strings (~> 1.20240116.2)
+    - abseil/synchronization/synchronization (~> 1.20240116.2)
+    - abseil/time/time (~> 1.20240116.2)
+    - abseil/types/optional (~> 1.20240116.2)
+    - abseil/types/span (~> 1.20240116.2)
+    - abseil/types/variant (~> 1.20240116.2)
+    - abseil/utility/utility (~> 1.20240116.2)
+    - BoringSSL-GRPC (= 0.0.32)
+    - gRPC-Core/Interface (= 1.62.5)
+    - gRPC-Core/Privacy (= 1.62.5)
+  - gRPC-Core/Interface (1.62.5)
+  - gRPC-Core/Privacy (1.62.5)
+  - GTMAppAuth (4.1.1):
+    - AppAuth/Core (~> 1.7)
+    - GTMSessionFetcher/Core (< 4.0, >= 3.3)
+  - GTMSessionFetcher/Core (3.5.0)
+  - leveldb-library (1.22.5)
+  - nanopb (2.30910.0):
+    - nanopb/decode (= 2.30910.0)
+    - nanopb/encode (= 2.30910.0)
+  - nanopb/decode (2.30910.0)
+  - nanopb/encode (2.30910.0)
+  - PromisesObjC (2.4.0)
   - RecaptchaInterop (100.0.0)
-  - SDWebImage (5.18.2):
-    - SDWebImage/Core (= 5.18.2)
-  - SDWebImage/Core (5.18.2)
+  - SDWebImage (5.19.4):
+    - SDWebImage/Core (= 5.19.4)
+  - SDWebImage/Core (5.19.4)
 
 DEPENDENCIES:
   - FirebaseAnonymousAuthUI (from `../../`)
@@ -882,6 +1237,8 @@ SPEC REPOS:
     - FirebaseCoreInternal
     - FirebaseDatabase
     - FirebaseFirestore
+    - FirebaseFirestoreInternal
+    - FirebaseSharedSwift
     - FirebaseStorage
     - GoogleSignIn
     - GoogleUtilities
@@ -920,45 +1277,47 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  abseil: 926fb7a82dc6d2b8e1f2ed7f3a718bce691d1e46
-  AppAuth: 3bb1d1cd9340bd09f5ed189fb00b1cc28e1e8570
-  BoringSSL-GRPC: 3175b25143e648463a56daeaaa499c6cb86dad33
-  FBAEMKit: 5facf4292bff062963f563d68fd5c0cdd6c90d63
-  FBSDKCoreKit: f94e107ae84a6f4c0d9edfd06ed989b084bfa5bb
-  FBSDKCoreKit_Basics: 8123411ba15df07f9a8da760630f4cdfeeaea6a7
-  FBSDKLoginKit: ae454ceaeb9ee753caf78242bdad1b5226968358
-  FirebaseAnonymousAuthUI: 03392075a7f79a674b49af1678989ded80e106f2
-  FirebaseAppCheckInterop: a8c555b1c2db1d9445e6c3a08a848167ddb7eb51
-  FirebaseAuth: a55ec5f7f8a5b1c2dd750235c1bb419bfb642445
-  FirebaseAuthInterop: b566e21e2bc5e44a4d44babc56d05a7e5c10493b
-  FirebaseAuthUI: 9b4de780078d674019a2bfc560bb812f23b45ff1
-  FirebaseCore: 2cec518b43635f96afe7ac3a9c513e47558abd2e
-  FirebaseCoreExtension: d3f1ea3725fb41f56e8fbfb29eeaff54e7ffb8f6
-  FirebaseCoreInternal: 2f4bee5ed00301b5e56da0849268797a2dd31fb4
-  FirebaseDatabase: f93f1481c7e9e3d77af960cdff82a408d37693e6
-  FirebaseDatabaseUI: 13f9d60a13ac9e35a4121e1cb20ba69d4de7ed7e
-  FirebaseEmailAuthUI: 548b1b5b557b67b15fd3197d18da29d91a154ef8
-  FirebaseFacebookAuthUI: 2f10fb7eb4ca4e507e266dc65b544dbc548e2238
-  FirebaseFirestore: b4c0eaaf24efda5732ec21d9e6c788d083118ca6
-  FirebaseFirestoreUI: 98ddae8daaea34a3c8bc0a51e4f5c104b997f8b8
-  FirebaseGoogleAuthUI: 420e5b1c10f13a47c18579303d93275842f1a8a0
-  FirebaseOAuthUI: 5f19522e97d992841163d89a0b44afe315674020
-  FirebasePhoneAuthUI: 4e32b332ba0484a0b6cf8246c93c23a24f9dbcad
-  FirebaseStorage: 1d4be239ea32fb3c0f3680a6f2b706d6cabe37f2
-  FirebaseStorageUI: 5db14fc4c251fdbe3b706eb1a9dddc55bc51b414
-  FirebaseUI: d3e0d3f81f5c464554945195a6133a3ab905b6a7
-  GoogleSignIn: 5651ce3a61e56ca864160e79b484cd9ed3f49b7a
-  GoogleUtilities: 13e2c67ede716b8741c7989e26893d151b2b2084
-  "gRPC-C++": 0968bace703459fd3e5dcb0b2bed4c573dbff046
-  gRPC-Core: 17108291d84332196d3c8466b48f016fc17d816d
-  GTMAppAuth: 0ff230db599948a9ad7470ca667337803b3fc4dd
-  GTMSessionFetcher: 3a63d75eecd6aa32c2fc79f578064e1214dfdec2
-  leveldb-library: f03246171cce0484482ec291f88b6d563699ee06
-  nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
-  PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
+  abseil: d121da9ef7e2ff4cab7666e76c5a3e0915ae08c3
+  AppAuth: 501c04eda8a8d11f179dbe8637b7a91bb7e5d2fa
+  BoringSSL-GRPC: 1e2348957acdbcad360b80a264a90799984b2ba6
+  FBAEMKit: 6c7b5eb77c96861bb59e040842c6e55bf39512ce
+  FBSDKCoreKit: 5e4dd478947ab1bcc887e8cfadeae0727af1a942
+  FBSDKCoreKit_Basics: cd7b5f5d1e8868c26706917919d058999ca672c3
+  FBSDKLoginKit: 572cca0bc6c90067ef197187697cb3b584310c52
+  FirebaseAnonymousAuthUI: 343c325a1506abbee11f33918f9d3c58a5b19f12
+  FirebaseAppCheckInterop: 6a1757cfd4067d8e00fccd14fcc1b8fd78cfac07
+  FirebaseAuth: e2ebfaf9fb4638a1c9a3b0efd17d1b90943987cd
+  FirebaseAuthInterop: 17db81e9b198afb0f95ce48c133825727eed55d3
+  FirebaseAuthUI: f03542565fe2e44a8fbb756ffceb17a8506aad43
+  FirebaseCore: 30e9c1cbe3d38f5f5e75f48bfcea87d7c358ec16
+  FirebaseCoreExtension: 705ca5b14bf71d2564a0ddc677df1fc86ffa600f
+  FirebaseCoreInternal: df84dd300b561c27d5571684f389bf60b0a5c934
+  FirebaseDatabase: 1fecbdd38d325c78bd430c06b8e71794ce415dc7
+  FirebaseDatabaseUI: fa413a4300fa3cba5320958f41ad69d0439b8950
+  FirebaseEmailAuthUI: 79469bad01da0017128d7e099411707c6273435c
+  FirebaseFacebookAuthUI: 351929201d36bb1b110a151f44a6b89907e6421a
+  FirebaseFirestore: f258936f52d712337233182b90042a76ff48dce0
+  FirebaseFirestoreInternal: f43d25cc04835ec3aa1885f4fc946a1a4f9e1c56
+  FirebaseFirestoreUI: b2b0421c3b0abbcd481df7869bed7bc246f35855
+  FirebaseGoogleAuthUI: e48f6c315259701524863c461a27778e5995401e
+  FirebaseOAuthUI: 13e6b83a4e9680f2806107d7b383ede1f550e499
+  FirebasePhoneAuthUI: ac09045887000af5f7aad87cac641607ceabdd0b
+  FirebaseSharedSwift: 20530f495084b8d840f78a100d8c5ee613375f6e
+  FirebaseStorage: 436c30aa46f2177ba152f268fe4452118b8a4856
+  FirebaseStorageUI: 22fcea916105f65d47d38a3108b540282cab229d
+  FirebaseUI: 73a3f84e38d62824a9582d41a5d5bab39cc499aa
+  GoogleSignIn: d4281ab6cf21542b1cfaff85c191f230b399d2db
+  GoogleUtilities: ea963c370a38a8069cc5f7ba4ca849a60b6d7d15
+  "gRPC-C++": e725ef63c4475d7cdb7e2cf16eb0fde84bd9ee51
+  gRPC-Core: eee4be35df218649fe66d721a05a7f27a28f069b
+  GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
+  GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
+  leveldb-library: e8eadf9008a61f9e1dde3978c086d2b6d9b9dc28
+  nanopb: 438bc412db1928dac798aa6fd75726007be04262
+  PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
-  SDWebImage: c0de394d7cf7f9838aed1fd6bb6037654a4572e4
+  SDWebImage: 066c47b573f408f18caa467d71deace7c0f8280d
 
 PODFILE CHECKSUM: 2c24841f482dcea2f8eb8b3a4c3bfeda6423a0b3
 
-COCOAPODS: 1.13.0
+COCOAPODS: 1.15.2


### PR DESCRIPTION
Build from SPM with both Firebase 10 and Firebase 11

Migrate to GoogleSignIn 7. I disabled and left a TODO for the unit tests that need to be updated in ` FirebaseGoogleAuthUITests/FirebaseGoogleAuthUITests.m`

There are several ugly string changes because SPM does not include the libraries global string constants. (CocoaPods does). 

Once the minimum dependency is Firebase 11, they can be updated to the Swift symbol.
