### PR TITLE
Fix build regression

### DIFF
--- a/FirebaseAuthUI.podspec
+++ b/FirebaseAuthUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseAuthUI'
-  s.version      = '14.2.0'
+  s.version      = '14.2.1'
   s.summary      = 'A prebuilt authentication UI flow for Firebase Auth.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }

--- a/FirebaseAuthUI/FirebaseAuthUITests/FUIAuthTest.m
+++ b/FirebaseAuthUI/FirebaseAuthUITests/FUIAuthTest.m
@@ -15,6 +15,7 @@
 //
 
 @import XCTest;
+@import FirebaseAuth;
 @import FirebaseCore;
 
 #import "FUIAuth.h"

--- a/FirebaseAuthUI/Sources/Public/FirebaseAuthUI/FUIAuth.h
+++ b/FirebaseAuthUI/Sources/Public/FirebaseAuthUI/FUIAuth.h
@@ -20,6 +20,7 @@
 #import "FUIAuthProvider.h"
 
 @class FIRAuth;
+@class FIRAuthDataResult;
 @class FUIAuthPickerViewController;
 @class FUIAuth;
 @class FIRUser;

--- a/FirebaseAuthUI/Sources/Public/FirebaseAuthUI/FUIAuthProvider.h
+++ b/FirebaseAuthUI/Sources/Public/FirebaseAuthUI/FUIAuthProvider.h
@@ -15,10 +15,10 @@
 //
 
 #import <UIKit/UIKit.h>
-@import FirebaseAuth;
 
 @class FIRAuth;
 @class FIRAuthCredential;
+@class FIRUser;
 @class FIRUserInfo;
 
 typedef void (^FIRAuthResultCallback)(FIRUser *_Nullable user, NSError *_Nullable error);

--- a/FirebasePhoneAuthUI.podspec
+++ b/FirebasePhoneAuthUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebasePhoneAuthUI'
-  s.version      = '14.2.0'
+  s.version      = '14.2.1'
   s.summary      = 'A phone auth provider for FirebaseAuthUI.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }

--- a/FirebasePhoneAuthUI/Sources/FUIPhoneAuth.m
+++ b/FirebasePhoneAuthUI/Sources/FUIPhoneAuth.m
@@ -83,7 +83,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - FUIAuthProvider
 
 - (nullable NSString *)providerID {
-  return FIRPhoneAuthProviderID;
+  return @"phone";
 }
 
 /** @fn accessToken:
@@ -147,11 +147,11 @@ NS_ASSUME_NONNULL_BEGIN
                     completion:(nullable FUIAuthProviderSignInCompletionBlock)completion {
   _pendingSignInCallback = completion;
   
-  FUIPhoneAuth *delegate = [_authUI providerWithID:FIRPhoneAuthProviderID];
+  FUIPhoneAuth *delegate = [_authUI providerWithID:@"phone"];
   if (!delegate) {
     NSError *error = [FUIAuthErrorUtils errorWithCode:FUIAuthErrorCodeCantFindProvider
                                              userInfo:@{
-                       FUIAuthErrorUserInfoProviderIDKey : FIRPhoneAuthProviderID
+                       FUIAuthErrorUserInfoProviderIDKey : @"phone"
                      }];
     [self callbackWithCredential:nil error:error result:^(FIRUser *_Nullable user,
                                                           NSError *_Nullable error) {

--- a/FirebasePhoneAuthUI/Sources/FUIPhoneEntryViewController.m
+++ b/FirebasePhoneAuthUI/Sources/FUIPhoneEntryViewController.m
@@ -112,7 +112,7 @@ static NSString *const kNextButtonAccessibilityID = @"NextButtonAccessibilityID"
   if (self) {
     self.title = FUIPhoneAuthLocalizedString(kPAStr_EnterPhoneTitle);
     _countryCodes = countryCodes ?: [[FUICountryCodes alloc] init];
-    FUIPhoneAuth *provider = [authUI providerWithID:FIRPhoneAuthProviderID];
+    FUIPhoneAuth *provider = [authUI providerWithID:@"phone"];
     NSString *defaultCountryCode = provider.defaultCountryCode;
     _countryCodes.defaultCountryCodeInfo =
         [_countryCodes countryCodeInfoForCode:defaultCountryCode];
@@ -221,7 +221,7 @@ static NSString *const kNextButtonAccessibilityID = @"NextButtonAccessibilityID"
                                                                      actionHandler:nil];
         [self presentViewController:alertController animated:YES completion:nil];
         
-        FUIPhoneAuth *delegate = [self.authUI providerWithID:FIRPhoneAuthProviderID];
+        FUIPhoneAuth *delegate = [self.authUI providerWithID:@"phone"];
         [delegate callbackWithCredential:nil error:error result:nil];
         return;
       }
@@ -360,7 +360,7 @@ static NSString *const kNextButtonAccessibilityID = @"NextButtonAccessibilityID"
 
 - (void)cancelAuthorization {
   NSError *error = [FUIAuthErrorUtils userCancelledSignInError];
-  FUIPhoneAuth *delegate = [self.authUI providerWithID:FIRPhoneAuthProviderID];
+  FUIPhoneAuth *delegate = [self.authUI providerWithID:@"phone"];
   [delegate callbackWithCredential:nil error:error result:^(FIRUser *_Nullable user,
                                                             NSError *_Nullable error) {
     if (!error || error.code == FUIAuthErrorCodeUserCancelledSignIn) {

--- a/FirebasePhoneAuthUI/Sources/FUIPhoneVerificationViewController.m
+++ b/FirebasePhoneAuthUI/Sources/FUIPhoneVerificationViewController.m
@@ -185,7 +185,7 @@ static NSString *const kLinkPlaceholderPattern = @"\\[([^\\]]+)\\]";
   [self incrementActivity];
   [_codeField resignFirstResponder];
   self.navigationItem.rightBarButtonItem.enabled = NO;
-  FUIPhoneAuth *delegate = [self.authUI providerWithID:FIRPhoneAuthProviderID];
+  FUIPhoneAuth *delegate = [self.authUI providerWithID:@"phone"];
   [delegate callbackWithCredential:credential
                              error:nil
                             result:^(FIRUser *_Nullable user, NSError *_Nullable error) {
@@ -221,7 +221,7 @@ static NSString *const kLinkPlaceholderPattern = @"\\[([^\\]]+)\\]";
 
 - (void)cancelAuthorization {
   NSError *error = [FUIAuthErrorUtils userCancelledSignInError];
-  FUIPhoneAuth *delegate = [self.authUI providerWithID:FIRPhoneAuthProviderID];
+  FUIPhoneAuth *delegate = [self.authUI providerWithID:@"phone"];
   [delegate callbackWithCredential:nil
                              error:error
                             result:^(FIRUser *_Nullable user, NSError *_Nullable error) {


### PR DESCRIPTION
Public headers should not do module imports.

Make fix and prepare a 14.2.1 for FirebaseAuthUI.

Import all SPM targets into a sample app to test build and fix  PhoneAuthUI issues with hard-coded constant so it works with both Firebase 10 and 11.

Fix #1196
