### PR TITLE
Update config for GSI v7

### DIFF
--- a/FirebaseGoogleAuthUI.podspec
+++ b/FirebaseGoogleAuthUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseGoogleAuthUI'
-  s.version      = '14.2.0'
+  s.version      = '14.2.2'
   s.summary      = 'Google authentication for FirebaseAuthUI.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }

--- a/FirebaseGoogleAuthUI/Sources/FUIGoogleAuth.m
+++ b/FirebaseGoogleAuthUI/Sources/FUIGoogleAuth.m
@@ -193,6 +193,8 @@ static NSString *const kSignInWithGoogle = @"SignInWithGoogle";
     }
   };
 
+  signIn.configuration = [[GIDConfiguration alloc] initWithClientID:clientID];
+
   [signIn signInWithPresentingViewController:presentingViewController
                                         hint:defaultValue completion:^(GIDSignInResult * _Nullable signInResult, NSError * _Nullable error) {
     [self handleSignInWithUser:signInResult.user


### PR DESCRIPTION
Fix #1198 

The GSI config needs to be initialized with the clientID for GSI 7+