### PR TITLE
Make sure FUIAuthDelegate methods get called for Firebase 11

### DIFF
--- a/FirebaseAuthUI.podspec
+++ b/FirebaseAuthUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FirebaseAuthUI'
-  s.version      = '14.2.3'
+  s.version      = '14.2.4'
   s.summary      = 'A prebuilt authentication UI flow for Firebase Auth.'
   s.homepage     = 'https://github.com/firebase/FirebaseUI-iOS'
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }

--- a/FirebaseAuthUI/Sources/FUIAuth.m
+++ b/FirebaseAuthUI/Sources/FUIAuth.m
@@ -352,6 +352,7 @@ static NSString *const kFirebaseAuthUIFrameworkMarker = @"FirebaseUI-iOS";
                                            URL:(nullable NSURL *)url
                                          error:(nullable NSError *)error {
   dispatch_async(dispatch_get_main_queue(), ^{
+    // Firebase 10 signatures.
     if ([self.delegate respondsToSelector:@selector(authUI:didSignInWithAuthDataResult:URL:error:)]) {
       [self.delegate authUI:self
           didSignInWithAuthDataResult:authDataResult
@@ -360,6 +361,13 @@ static NSString *const kFirebaseAuthUIFrameworkMarker = @"FirebaseUI-iOS";
     }
     if ([self.delegate respondsToSelector:@selector(authUI:didSignInWithAuthDataResult:error:)]) {
       [self.delegate authUI:self didSignInWithAuthDataResult:authDataResult error:error];
+    }
+    // Firebase 11+ signatures.
+    if ([self.delegate respondsToSelector:@selector(authUI:didSignInWith:URL:error:)]) {
+      [self.delegate authUI:self didSignInWith:authDataResult URL:url error:error];
+    }
+    if ([self.delegate respondsToSelector:@selector(authUI:didSignInWith:error:)]) {
+      [self.delegate authUI:self didSignInWith:authDataResult error:error];
     }
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"

--- a/FirebaseAuthUI/Sources/Public/FirebaseAuthUI/FUIAuth.h
+++ b/FirebaseAuthUI/Sources/Public/FirebaseAuthUI/FUIAuth.h
@@ -48,7 +48,7 @@ typedef void (^FUIAuthResultCallback)(FIRUser *_Nullable user, NSError *_Nullabl
 
 /** @fn authUI:didSignInWithAuthDataResult:error:
     @brief Message sent after the sign in process has completed to report the signed in user or
-        error encountered.
+        error encountered. Use this variation with Firebase 10 and earlier.
     @param authUI The @c FUIAuth instance sending the message.
     @param authDataResult The data result if the sign in attempt was successful.
     @param url pass the deep link associated with an email link sign-in completion. It is useful
@@ -62,7 +62,22 @@ typedef void (^FUIAuthResultCallback)(FIRUser *_Nullable user, NSError *_Nullabl
 
 /** @fn authUI:didSignInWithAuthDataResult:error:
     @brief Message sent after the sign in process has completed to report the signed in user or
-        error encountered.
+        error encountered. Use this variation with Firebase 11 and later. Swift implementations
+        should be marked with `@objc`.
+    @param authUI The @c FUIAuth instance sending the message.
+    @param authDataResult The data result if the sign in attempt was successful.
+    @param url pass the deep link associated with an email link sign-in completion. It is useful
+               for the developer to access the state before the sign-in attempt was triggered.
+    @param error The error that occurred during sign in, if any.
+ */
+- (void)authUI:(FUIAuth *)authUI
+    didSignInWith:(nullable FIRAuthDataResult *)authDataResult
+              URL:(nullable NSURL *)url
+            error:(nullable NSError *)error;
+
+/** @fn authUI:didSignInWithAuthDataResult:error:
+    @brief Message sent after the sign in process has completed to report the signed in user or
+        error encountered. Use this variation with Firebase 10 and earlier.
     @param authUI The @c FUIAuth instance sending the message.
     @param authDataResult The data result if the sign in attempt was successful.
     @param error The error that occurred during sign in, if any.
@@ -70,6 +85,18 @@ typedef void (^FUIAuthResultCallback)(FIRUser *_Nullable user, NSError *_Nullabl
 - (void)authUI:(FUIAuth *)authUI
     didSignInWithAuthDataResult:(nullable FIRAuthDataResult *)authDataResult
                           error:(nullable NSError *)error;
+
+/** @fn authUI:didSignInWithAuthDataResult:error:
+    @brief Message sent after the sign in process has completed to report the signed in user or
+        error encountered. Use this variation with Firebase 11 and later. Swift implementations
+        should be marked with `@objc`.
+    @param authUI The @c FUIAuth instance sending the message.
+    @param authDataResult The data result if the sign in attempt was successful.
+    @param error The error that occurred during sign in, if any.
+ */
+- (void)authUI:(FUIAuth *)authUI
+    didSignInWith:(nullable FIRAuthDataResult *)authDataResult
+            error:(nullable NSError *)error;
 
 /** @fn authUI:didSignInWithUser:error:
     @brief This is deprecated API and will be removed in a future release.


### PR DESCRIPTION
Fix #1198

The function `func authUI(_ authUI: FUIAuth, didSignInWith authDataResult: AuthDataResult?, error: Error?) ` maps to Objective C selectors differently between Firebase 10 and Firebase 11. 

With Firebase 10, it becomes
```
@selector(authUI:didSignInWithAuthDataResult:error:)
```
With Firebase 11, it becomes
```
@selector(authUI:didSignInWith:error:)
```

Also, with Firebase 11, an `@objc` is required on Swift implementations.