### PR TITLE
Set activity indicator color to white

### DIFF
--- a/FirebaseAuthUI/Sources/FUIAuthBaseViewController.m
+++ b/FirebaseAuthUI/Sources/FUIAuthBaseViewController.m
@@ -132,6 +132,7 @@ static NSString *const kAuthUICodingKey = @"authUI";
   UIActivityIndicatorView *activityIndicator =
       [[UIActivityIndicatorView alloc]
        initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleLarge];
+  activityIndicator.color = [UIColor colorWithWhite:1 alpha:1];
   UIView *tintView = [[UIView alloc] initWithFrame:CGRectInset(activityIndicator.frame,
                                                                -kActivityIndiactorPadding,
                                                                -kActivityIndiactorPadding)];


### PR DESCRIPTION
Resolves #1207

Fix discussed here: https://github.com/firebase/FirebaseUI-iOS/pull/1194#issuecomment-2425585653

I have tested and confirmed that this change works for my app using Phone authentication with FirebaseUI `14.2.4` on iOS `18.0.1`.