### PR TITLE
fix: objective-c sample app bugs

### DIFF
--- a/samples/objc/FirebaseUI-demo-objc/Samples/Auth/FUIAuthViewController.m
+++ b/samples/objc/FirebaseUI-demo-objc/Samples/Auth/FUIAuthViewController.m
@@ -262,7 +262,7 @@ static NSString *const kFirebasePrivacyPolicy = @"https://firebase.google.com/su
 
     NSString *providerID = self.authUI.providers.firstObject.providerID;
     BOOL isPhoneAuth = [providerID isEqualToString:FIRPhoneAuthProviderID];
-    BOOL isEmailAuth = [providerID isEqualToString:@
+    BOOL isEmailAuth = [providerID isEqualToString:
 @"password"];
     BOOL shouldSkipAuthPicker = self.authUI.providers.count == 1 && (isPhoneAuth || isEmailAuth);
     if (shouldSkipAuthPicker) {

--- a/samples/objc/FirebaseUI-demo-objc/Samples/Storage/FUIStorageViewController.m
+++ b/samples/objc/FirebaseUI-demo-objc/Samples/Storage/FUIStorageViewController.m
@@ -19,8 +19,7 @@
 @import FirebaseStorageUI;
 
 #import "FUIStorageViewController.h"
-
-#import <FirebaseStorage/FirebaseStorage.h>
+#import <FirebaseStorage/FirebaseStorage-Swift.h>
 
 @interface FUIStorageViewController ()
 @property (nonatomic, strong) IBOutlet UIImageView *imageView;


### PR DESCRIPTION
A couple of fixes for the objective-c sample app:

- fixes firebase storage import.
- removed duplicate `@` symbol.
