### PR TITLE
fix: swift example app fixes

### DIFF
--- a/samples/swift/FirebaseUI-demo-swift/FUIAppDelegate.swift
+++ b/samples/swift/FirebaseUI-demo-swift/FUIAppDelegate.swift
@@ -21,7 +21,7 @@ import FirebaseAuth
 import FirebaseAuthUI
 import GTMSessionFetcher
 
-@UIApplicationMain
+@main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
   var window: UIWindow?

--- a/samples/swift/FirebaseUI-demo-swift/Samples/Auth/FUICustomAuthUIDelegate.swift
+++ b/samples/swift/FirebaseUI-demo-swift/Samples/Auth/FUICustomAuthUIDelegate.swift
@@ -18,7 +18,7 @@ import UIKit
 import FirebaseAuth
 import FirebaseEmailAuthUI
 
-class FUICustomAuthDelegate: NSObject, FUIAuthDelegate {
+class FUICustomAuthDelegate: NSObject, @preconcurrency FUIAuthDelegate {
 
   @objc func authUI(_ authUI: FUIAuth, didSignInWith authDataResult: AuthDataResult?, error: Error?) {
     switch error {
@@ -33,33 +33,33 @@ class FUICustomAuthDelegate: NSObject, FUIAuthDelegate {
     }
   }
 
-  func authPickerViewController(forAuthUI authUI: FUIAuth) -> FUIAuthPickerViewController {
+  @MainActor func authPickerViewController(forAuthUI authUI: FUIAuth) -> FUIAuthPickerViewController {
     return FUICustomAuthPickerViewController(nibName: "FUICustomAuthPickerViewController",
                                              bundle: Bundle.main,
                                              authUI: authUI)
   }
 
-  func emailEntryViewController(forAuthUI authUI: FUIAuth) -> FUIEmailEntryViewController {
+  @MainActor func emailEntryViewController(forAuthUI authUI: FUIAuth) -> FUIEmailEntryViewController {
     return FUICustomEmailEntryViewController(nibName: "FUICustomEmailEntryViewController",
                                              bundle: Bundle.main,
                                              authUI: authUI)
   }
 
-  func passwordRecoveryViewController(forAuthUI authUI: FUIAuth, email: String?) -> FUIPasswordRecoveryViewController {
+  @MainActor func passwordRecoveryViewController(forAuthUI authUI: FUIAuth, email: String?) -> FUIPasswordRecoveryViewController {
     return FUICustomPasswordRecoveryViewController(nibName: "FUICustomPasswordRecoveryViewController",
                                                    bundle: Bundle.main,
                                                    authUI: authUI,
                                                    email: email)
   }
 
-  func passwordSignInViewController(forAuthUI authUI: FUIAuth, email: String?) -> FUIPasswordSignInViewController {
+  @MainActor func passwordSignInViewController(forAuthUI authUI: FUIAuth, email: String?) -> FUIPasswordSignInViewController {
     return FUICustomPasswordSignInViewController(nibName: "FUICustomPasswordSignInViewController",
                                                  bundle: Bundle.main,
                                                  authUI: authUI,
                                                  email: email)
   }
 
-  func passwordSignUpViewController(forAuthUI authUI: FUIAuth, email: String) -> FUIPasswordSignUpViewController {
+  @MainActor func passwordSignUpViewController(forAuthUI authUI: FUIAuth, email: String) -> FUIPasswordSignUpViewController {
     return FUICustomPasswordSignUpViewController(nibName: "FUICustomPasswordSignUpViewController",
                                                  bundle: Bundle.main,
                                                  authUI: authUI,
@@ -67,7 +67,7 @@ class FUICustomAuthDelegate: NSObject, FUIAuthDelegate {
                                                  requireDisplayName: true)
   }
 
-  func passwordVerificationViewController(forAuthUI authUI: FUIAuth, email: String?, newCredential: AuthCredential) -> FUIPasswordVerificationViewController {
+  @MainActor func passwordVerificationViewController(forAuthUI authUI: FUIAuth, email: String?, newCredential: AuthCredential) -> FUIPasswordVerificationViewController {
     return FUICustomPasswordVerificationViewController(nibName: "FUICustomPasswordVerificationViewController",
                                                        bundle: Bundle.main,
                                                        authUI: authUI,

--- a/samples/swift/FirebaseUI-demo-swift/Samples/Sample.swift
+++ b/samples/swift/FirebaseUI-demo-swift/Samples/Sample.swift
@@ -55,7 +55,7 @@ enum Sample: Int, RawRepresentable {
     }
   }
   
-  func controller() -> UIViewController {
+  @MainActor func controller() -> UIViewController {
     switch self {
     case .chat:
       return UIStoryboard.instantiateViewController("Main", identifier: "ChatViewController")


### PR DESCRIPTION
Swift example app fixes:

- `UIApplicationMain` is deprecated, updated to `main`.
- `@preconcurrency` attribute is required, I guess this was implemented before Swift 5.5.
- `@MainActor` Xcode complained if this attribute wasn't added, it indicates that function should run on main thread.