### PR TITLE
refactor: follow up PR with updates based on feedback

### DIFF
--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Services/AuthService.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Services/AuthService.swift
@@ -1,16 +1,16 @@
 @preconcurrency import FirebaseAuth
 import SwiftUI
 
-public protocol GoogleProviderProtocol {
+public protocol GoogleProviderAuthUIProtocol {
   func handleUrl(_ url: URL) -> Bool
   @MainActor func signInWithGoogle(clientID: String) async throws -> AuthCredential
 }
 
-public protocol FacebookProviderProtocol {
+public protocol FacebookProviderAuthUIProtocol {
   @MainActor func signInWithFacebook(isLimitedLogin: Bool) async throws -> AuthCredential
 }
 
-public protocol PhoneAuthProviderProtocol {
+public protocol PhoneAuthProviderAuthUIProtocol {
   @MainActor func verifyPhoneNumber(phoneNumber: String) async throws -> String
 }
 
@@ -61,9 +61,9 @@ private final class AuthListenerManager {
 @Observable
 public final class AuthService {
   public init(configuration: AuthConfiguration = AuthConfiguration(), auth: Auth = Auth.auth(),
-              googleProvider: GoogleProviderProtocol? = nil,
-              facebookProvider: FacebookProviderProtocol? = nil,
-              phoneAuthProvider: PhoneAuthProviderProtocol? = nil) {
+              googleProvider: GoogleProviderAuthUIProtocol? = nil,
+              facebookProvider: FacebookProviderAuthUIProtocol? = nil,
+              phoneAuthProvider: PhoneAuthProviderAuthUIProtocol? = nil) {
     self.auth = auth
     self.configuration = configuration
     self.googleProvider = googleProvider
@@ -85,11 +85,11 @@ public final class AuthService {
   public let passwordPrompt: PasswordPromptCoordinator = .init()
 
   private var listenerManager: AuthListenerManager?
-  private let googleProvider: GoogleProviderProtocol?
-  private let facebookProvider: FacebookProviderProtocol?
-  private let phoneAuthProvider: PhoneAuthProviderProtocol?
+  private let googleProvider: GoogleProviderAuthUIProtocol?
+  private let facebookProvider: FacebookProviderAuthUIProtocol?
+  private let phoneAuthProvider: PhoneAuthProviderAuthUIProtocol?
 
-  private var safeGoogleProvider: GoogleProviderProtocol {
+  private var safeGoogleProvider: GoogleProviderAuthUIProtocol {
     get throws {
       guard let provider = googleProvider else {
         throw AuthServiceError
@@ -99,7 +99,7 @@ public final class AuthService {
     }
   }
 
-  private var safeFacebookProvider: FacebookProviderProtocol {
+  private var safeFacebookProvider: FacebookProviderAuthUIProtocol {
     get throws {
       guard let provider = facebookProvider else {
         throw AuthServiceError
@@ -109,7 +109,7 @@ public final class AuthService {
     }
   }
 
-  private var safePhoneAuthProvider: PhoneAuthProviderProtocol {
+  private var safePhoneAuthProvider: PhoneAuthProviderAuthUIProtocol {
     get throws {
       guard let provider = phoneAuthProvider else {
         throw AuthServiceError

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Services/AuthService.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Services/AuthService.swift
@@ -6,15 +6,15 @@ public protocol ExternalAuthProvider {
   @MainActor var authButton: ButtonType { get }
 }
 
-public protocol GoogleProviderAuthUIProtocol {
+public protocol GoogleProviderAuthUIProtocol: ExternalAuthProvider {
   @MainActor func signInWithGoogle(clientID: String) async throws -> AuthCredential
 }
 
-public protocol FacebookProviderAuthUIProtocol {
+public protocol FacebookProviderAuthUIProtocol: ExternalAuthProvider {
   @MainActor func signInWithFacebook(isLimitedLogin: Bool) async throws -> AuthCredential
 }
 
-public protocol PhoneAuthProviderAuthUIProtocol {
+public protocol PhoneAuthProviderAuthUIProtocol: ExternalAuthProvider {
   @MainActor func verifyPhoneNumber(phoneNumber: String) async throws -> String
 }
 
@@ -66,9 +66,9 @@ private final class AuthListenerManager {
 @Observable
 public final class AuthService {
   public init(configuration: AuthConfiguration = AuthConfiguration(), auth: Auth = Auth.auth(),
-              googleProvider: GoogleProviderAuthUIProtocol? = nil,
-              facebookProvider: FacebookProviderAuthUIProtocol? = nil,
-              phoneAuthProvider: PhoneAuthProviderAuthUIProtocol? = nil) {
+              googleProvider: (any GoogleProviderAuthUIProtocol)? = nil,
+              facebookProvider: (any FacebookProviderAuthUIProtocol)? = nil,
+              phoneAuthProvider: (any PhoneAuthProviderAuthUIProtocol)? = nil) {
     self.auth = auth
     self.configuration = configuration
     self.googleProvider = googleProvider
@@ -106,7 +106,7 @@ public final class AuthService {
     }
   }
 
-  private var safeFacebookProvider: FacebookProviderAuthUIProtocol {
+  private var safeFacebookProvider: any FacebookProviderAuthUIProtocol {
     get throws {
       guard let provider = facebookProvider else {
         throw AuthServiceError
@@ -116,7 +116,7 @@ public final class AuthService {
     }
   }
 
-  private var safePhoneAuthProvider: PhoneAuthProviderAuthUIProtocol {
+  private var safePhoneAuthProvider: any PhoneAuthProviderAuthUIProtocol {
     get throws {
       guard let provider = phoneAuthProvider else {
         throw AuthServiceError

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/CommonUtils.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/CommonUtils.swift
@@ -47,8 +47,10 @@ public class CommonUtils {
     }
     return hash.map { String(format: "%02x", $0) }.joined()
   }
+}
 
-  public static func dummyConfigurationForPreview() {
+public extension FirebaseOptions {
+  static func dummyConfigurationForPreview() {
     guard FirebaseApp.app() == nil else { return }
 
     let options = FirebaseOptions(

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/CommonUtils.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/CommonUtils.swift
@@ -1,4 +1,5 @@
 import CommonCrypto
+import FirebaseCore
 import Foundation
 import Security
 
@@ -45,5 +46,20 @@ public class CommonUtils {
       _ = CC_SHA256($0.baseAddress, CC_LONG(data.count), &hash)
     }
     return hash.map { String(format: "%02x", $0) }.joined()
+  }
+
+  public static func dummyConfigurationForPreview() {
+    guard FirebaseApp.app() == nil else { return }
+
+    let options = FirebaseOptions(
+      googleAppID: "1:123:ios:123abc456def7890",
+      gcmSenderID: "dummy"
+    )
+    options.apiKey = "dummy"
+    options.projectID = "dummy-project-id"
+    options.bundleID = Bundle.main.bundleIdentifier ?? "com.example.dummy"
+    options.clientID = "dummy-abc.apps.googleusercontent.com"
+
+    FirebaseApp.configure(options: options)
   }
 }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/AuthPickerView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/AuthPickerView.swift
@@ -38,11 +38,11 @@ extension AuthPickerView: View {
             withAnimation {
               switchFlow()
             }
-          }) {
+          }, label: {
             Text(authService.authenticationFlow == .signUp ? "Log in" : "Sign up")
               .fontWeight(.semibold)
               .foregroundColor(.blue)
-          }
+          })
         }
         Text(authService.errorMessage).foregroundColor(.red)
       }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/AuthPickerView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/AuthPickerView.swift
@@ -38,11 +38,11 @@ extension AuthPickerView: View {
             withAnimation {
               switchFlow()
             }
-          }, label: {
+          }) {
             Text(authService.authenticationFlow == .signUp ? "Log in" : "Sign up")
               .fontWeight(.semibold)
               .foregroundColor(.blue)
-          })
+          }
         }
         Text(authService.errorMessage).foregroundColor(.red)
       }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/EmailAuthView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/EmailAuthView.swift
@@ -82,9 +82,9 @@ extension EmailAuthView: View {
       if authService.authenticationFlow == .login {
         Button(action: {
           authService.authView = .passwordRecovery
-        }, label: {
+        }) {
           Text("Forgotten Password?")
-        })
+        }
       }
 
       if authService.authenticationFlow == .signUp {
@@ -108,7 +108,7 @@ extension EmailAuthView: View {
           if authService.authenticationFlow == .login { await signInWithEmailPassword() }
           else { await createUserWithEmailPassword() }
         }
-      }, label: {
+      }) {
         if authService.authenticationState != .authenticating {
           Text(authService.authenticationFlow == .login ? "Log in with password" : "Sign up")
             .padding(.vertical, 8)
@@ -119,16 +119,16 @@ extension EmailAuthView: View {
             .padding(.vertical, 8)
             .frame(maxWidth: .infinity)
         }
-      })
+      }
       .disabled(!isValid)
       .padding([.top, .bottom], 8)
       .frame(maxWidth: .infinity)
       .buttonStyle(.borderedProminent)
       Button(action: {
         authService.authView = .passwordRecovery
-      }, label: {
+      }) {
         Text("Prefer Email link sign-in?")
-      })
+      }
     }
   }
 }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/EmailAuthView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/EmailAuthView.swift
@@ -82,9 +82,9 @@ extension EmailAuthView: View {
       if authService.authenticationFlow == .login {
         Button(action: {
           authService.authView = .passwordRecovery
-        }) {
+        }, label: {
           Text("Forgotten Password?")
-        }
+        })
       }
 
       if authService.authenticationFlow == .signUp {
@@ -108,7 +108,7 @@ extension EmailAuthView: View {
           if authService.authenticationFlow == .login { await signInWithEmailPassword() }
           else { await createUserWithEmailPassword() }
         }
-      }) {
+      }, label: {
         if authService.authenticationState != .authenticating {
           Text(authService.authenticationFlow == .login ? "Log in with password" : "Sign up")
             .padding(.vertical, 8)
@@ -119,16 +119,16 @@ extension EmailAuthView: View {
             .padding(.vertical, 8)
             .frame(maxWidth: .infinity)
         }
-      }
+      })
       .disabled(!isValid)
       .padding([.top, .bottom], 8)
       .frame(maxWidth: .infinity)
       .buttonStyle(.borderedProminent)
       Button(action: {
         authService.authView = .passwordRecovery
-      }) {
+      }, label: {
         Text("Prefer Email link sign-in?")
-      }
+      })
     }
   }
 }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/EmailAuthView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/EmailAuthView.swift
@@ -132,3 +132,9 @@ extension EmailAuthView: View {
     }
   }
 }
+
+#Preview {
+  CommonUtils.dummyConfigurationForPreview()
+  return EmailAuthView()
+    .environment(AuthService())
+}

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/EmailAuthView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/EmailAuthView.swift
@@ -5,6 +5,7 @@
 //  Created by Russell Wheatley on 20/03/2025.
 //
 import FirebaseAuth
+import FirebaseCore
 import SwiftUI
 
 private enum FocusableField: Hashable {
@@ -134,7 +135,7 @@ extension EmailAuthView: View {
 }
 
 #Preview {
-  CommonUtils.dummyConfigurationForPreview()
+  FirebaseOptions.dummyConfigurationForPreview()
   return EmailAuthView()
     .environment(AuthService())
 }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/EmailLinkView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/EmailLinkView.swift
@@ -67,12 +67,12 @@ extension EmailLinkView: View {
     }
     .navigationBarItems(leading: Button(action: {
       authService.authView = .authPicker
-    }, label: {
+    }) {
       Image(systemName: "chevron.left")
         .foregroundColor(.blue)
       Text("Back")
         .foregroundColor(.blue)
-    }))
+    })
   }
 }
 

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/EmailLinkView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/EmailLinkView.swift
@@ -35,11 +35,11 @@ extension EmailLinkView: View {
           await sendEmailLink()
           authService.emailLink = email
         }
-      }, label: {
+      }) {
         Text("Send email sign-in link")
           .padding(.vertical, 8)
           .frame(maxWidth: .infinity)
-      })
+      }
       .disabled(!CommonUtils.isValidEmail(email))
       .padding([.top, .bottom], 8)
       .frame(maxWidth: .infinity)

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/EmailLinkView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/EmailLinkView.swift
@@ -35,11 +35,11 @@ extension EmailLinkView: View {
           await sendEmailLink()
           authService.emailLink = email
         }
-      }) {
+      }, label: {
         Text("Send email sign-in link")
           .padding(.vertical, 8)
           .frame(maxWidth: .infinity)
-      }
+      })
       .disabled(!CommonUtils.isValidEmail(email))
       .padding([.top, .bottom], 8)
       .frame(maxWidth: .infinity)
@@ -66,11 +66,11 @@ extension EmailLinkView: View {
     }
     .navigationBarItems(leading: Button(action: {
       authService.authView = .authPicker
-    }) {
+    }, label: {
       Image(systemName: "chevron.left")
         .foregroundColor(.blue)
       Text("Back")
         .foregroundColor(.blue)
-    })
+    }))
   }
 }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/EmailLinkView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/EmailLinkView.swift
@@ -1,4 +1,5 @@
 import FirebaseAuth
+import FirebaseCore
 import SwiftUI
 
 public struct EmailLinkView {
@@ -76,7 +77,7 @@ extension EmailLinkView: View {
 }
 
 #Preview {
-  CommonUtils.dummyConfigurationForPreview()
+  FirebaseOptions.dummyConfigurationForPreview()
   return EmailLinkView()
     .environment(AuthService())
 }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/EmailLinkView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/EmailLinkView.swift
@@ -74,3 +74,9 @@ extension EmailLinkView: View {
     }))
   }
 }
+
+#Preview {
+  CommonUtils.dummyConfigurationForPreview()
+  return EmailLinkView()
+    .environment(AuthService())
+}

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/PasswordPromptView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/PasswordPromptView.swift
@@ -27,3 +27,7 @@ extension PasswordPromptSheet: View {
     .padding()
   }
 }
+
+#Preview {
+  PasswordPromptSheet(coordinator: PasswordPromptCoordinator())
+}

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/PasswordRecoveryView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/PasswordRecoveryView.swift
@@ -67,3 +67,9 @@ extension PasswordRecoveryView: View {
     }))
   }
 }
+
+#Preview {
+  CommonUtils.dummyConfigurationForPreview()
+  return PasswordRecoveryView()
+    .environment(AuthService())
+}

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/PasswordRecoveryView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/PasswordRecoveryView.swift
@@ -60,12 +60,12 @@ extension PasswordRecoveryView: View {
     }
     .navigationBarItems(leading: Button(action: {
       authService.authView = .authPicker
-    }, label: {
+    }) {
       Image(systemName: "chevron.left")
         .foregroundColor(.blue)
       Text("Back")
         .foregroundColor(.blue)
-    }))
+    })
   }
 }
 

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/PasswordRecoveryView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/PasswordRecoveryView.swift
@@ -1,3 +1,4 @@
+import FirebaseCore
 import SwiftUI
 
 public struct PasswordRecoveryView {
@@ -69,7 +70,7 @@ extension PasswordRecoveryView: View {
 }
 
 #Preview {
-  CommonUtils.dummyConfigurationForPreview()
+  FirebaseOptions.dummyConfigurationForPreview()
   return PasswordRecoveryView()
     .environment(AuthService())
 }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/PasswordRecoveryView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/PasswordRecoveryView.swift
@@ -33,11 +33,11 @@ extension PasswordRecoveryView: View {
         Task {
           await sendPasswordRecoveryEmail()
         }
-      }) {
+      }, label: {
         Text("Password Recovery")
           .padding(.vertical, 8)
           .frame(maxWidth: .infinity)
-      }
+      })
       .disabled(!CommonUtils.isValidEmail(email))
       .padding([.top, .bottom], 8)
       .frame(maxWidth: .infinity)
@@ -59,11 +59,11 @@ extension PasswordRecoveryView: View {
     }
     .navigationBarItems(leading: Button(action: {
       authService.authView = .authPicker
-    }) {
+    }, label: {
       Image(systemName: "chevron.left")
         .foregroundColor(.blue)
       Text("Back")
         .foregroundColor(.blue)
-    })
+    }))
   }
 }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/PasswordRecoveryView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/PasswordRecoveryView.swift
@@ -33,11 +33,11 @@ extension PasswordRecoveryView: View {
         Task {
           await sendPasswordRecoveryEmail()
         }
-      }, label: {
+      }) {
         Text("Password Recovery")
           .padding(.vertical, 8)
           .frame(maxWidth: .infinity)
-      })
+      }
       .disabled(!CommonUtils.isValidEmail(email))
       .padding([.top, .bottom], 8)
       .frame(maxWidth: .infinity)

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/SignedInView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/SignedInView.swift
@@ -1,3 +1,4 @@
+import FirebaseCore
 import SwiftUI
 
 @MainActor
@@ -45,7 +46,7 @@ extension SignedInView: View {
 }
 
 #Preview {
-  CommonUtils.dummyConfigurationForPreview()
+  FirebaseOptions.dummyConfigurationForPreview()
   return SignedInView()
     .environment(AuthService())
 }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/SignedInView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/SignedInView.swift
@@ -43,3 +43,9 @@ extension SignedInView: View {
     }
   }
 }
+
+#Preview {
+  CommonUtils.dummyConfigurationForPreview()
+  return SignedInView()
+    .environment(AuthService())
+}

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/VerifyEmailView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/VerifyEmailView.swift
@@ -42,3 +42,9 @@ extension VerifyEmailView: View {
     }
   }
 }
+
+#Preview {
+  CommonUtils.dummyConfigurationForPreview()
+  return VerifyEmailView()
+    .environment(AuthService())
+}

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/VerifyEmailView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/VerifyEmailView.swift
@@ -1,3 +1,4 @@
+import FirebaseCore
 import SwiftUI
 
 public struct VerifyEmailView {
@@ -44,7 +45,7 @@ extension VerifyEmailView: View {
 }
 
 #Preview {
-  CommonUtils.dummyConfigurationForPreview()
+  FirebaseOptions.dummyConfigurationForPreview()
   return VerifyEmailView()
     .environment(AuthService())
 }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/VerifyEmailView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/VerifyEmailView.swift
@@ -19,11 +19,11 @@ extension VerifyEmailView: View {
         Task {
           await sendEmailVerification()
         }
-      }) {
+      }, label: {
         Text("Verify email address?")
           .padding(.vertical, 8)
           .frame(maxWidth: .infinity)
-      }
+      })
       .padding([.top, .bottom], 8)
       .frame(maxWidth: .infinity)
       .buttonStyle(.borderedProminent)

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/VerifyEmailView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/VerifyEmailView.swift
@@ -19,11 +19,11 @@ extension VerifyEmailView: View {
         Task {
           await sendEmailVerification()
         }
-      }, label: {
+      }) {
         Text("Verify email address?")
           .padding(.vertical, 8)
           .frame(maxWidth: .infinity)
-      })
+      }
       .padding([.top, .bottom], 8)
       .frame(maxWidth: .infinity)
       .buttonStyle(.borderedProminent)

--- a/FirebaseSwiftUI/FirebaseFacebookSwiftUI/Sources/Services/FacebookProviderAuthUI.swift
+++ b/FirebaseSwiftUI/FirebaseFacebookSwiftUI/Sources/Services/FacebookProviderAuthUI.swift
@@ -20,7 +20,7 @@ public enum FacebookProviderError: Error {
   case authenticationToken(String)
 }
 
-public class FacebookProviderSwift: FacebookProviderProtocol {
+public class FacebookProviderAuthUI: FacebookProviderAuthUIProtocol {
   let scopes: [String]
   let shortName = "Facebook"
   let providerId = "facebook.com"

--- a/FirebaseSwiftUI/FirebaseFacebookSwiftUI/Sources/Views/SignInWithFacebookButton.swift
+++ b/FirebaseSwiftUI/FirebaseFacebookSwiftUI/Sources/Views/SignInWithFacebookButton.swift
@@ -60,7 +60,7 @@ extension SignInWithFacebookButton: View {
           }
         }
       }
-    }) {
+    }, label: {
       HStack {
         Image(systemName: "f.circle.fill")
           .font(.title)
@@ -73,7 +73,7 @@ extension SignInWithFacebookButton: View {
       .frame(maxWidth: .infinity)
       .background(Color.blue)
       .cornerRadius(8)
-    }
+    })
     .alert(isPresented: $showCanceledAlert) {
       Alert(
         title: Text("Facebook login cancelled"),

--- a/FirebaseSwiftUI/FirebaseFacebookSwiftUI/Sources/Views/SignInWithFacebookButton.swift
+++ b/FirebaseSwiftUI/FirebaseFacebookSwiftUI/Sources/Views/SignInWithFacebookButton.swift
@@ -3,6 +3,7 @@ import FacebookCore
 import FacebookLogin
 import FirebaseAuth
 import FirebaseAuthSwiftUI
+import FirebaseCore
 import SwiftUI
 
 @MainActor
@@ -110,7 +111,7 @@ extension SignInWithFacebookButton: View {
 }
 
 #Preview {
-  CommonUtils.dummyConfigurationForPreview()
+  FirebaseOptions.dummyConfigurationForPreview()
   return SignInWithFacebookButton()
     .environment(AuthService())
 }

--- a/FirebaseSwiftUI/FirebaseFacebookSwiftUI/Sources/Views/SignInWithFacebookButton.swift
+++ b/FirebaseSwiftUI/FirebaseFacebookSwiftUI/Sources/Views/SignInWithFacebookButton.swift
@@ -108,3 +108,9 @@ extension SignInWithFacebookButton: View {
     Text(errorMessage).foregroundColor(.red)
   }
 }
+
+#Preview {
+  CommonUtils.dummyConfigurationForPreview()
+  return SignInWithFacebookButton()
+    .environment(AuthService())
+}

--- a/FirebaseSwiftUI/FirebaseFacebookSwiftUI/Sources/Views/SignInWithFacebookButton.swift
+++ b/FirebaseSwiftUI/FirebaseFacebookSwiftUI/Sources/Views/SignInWithFacebookButton.swift
@@ -60,7 +60,7 @@ extension SignInWithFacebookButton: View {
           }
         }
       }
-    }, label: {
+    }) {
       HStack {
         Image(systemName: "f.circle.fill")
           .font(.title)
@@ -73,7 +73,7 @@ extension SignInWithFacebookButton: View {
       .frame(maxWidth: .infinity)
       .background(Color.blue)
       .cornerRadius(8)
-    })
+    }
     .alert(isPresented: $showCanceledAlert) {
       Alert(
         title: Text("Facebook login cancelled"),

--- a/FirebaseSwiftUI/FirebaseGoogleSwiftUI/Sources/Services/GoogleProviderAuthUI.swift
+++ b/FirebaseSwiftUI/FirebaseGoogleSwiftUI/Sources/Services/GoogleProviderAuthUI.swift
@@ -12,7 +12,7 @@ public enum GoogleProviderError: Error {
   case user(String)
 }
 
-public class GoogleProviderSwift: @preconcurrency GoogleProviderProtocol {
+public class GoogleProviderAuthUI: @preconcurrency GoogleProviderAuthUIProtocol {
   let scopes: [String]
   let shortName = "Google"
   let providerId = "google.com"

--- a/FirebaseSwiftUI/FirebaseGoogleSwiftUI/Sources/Views/SignInWithGoogleButton.swift
+++ b/FirebaseSwiftUI/FirebaseGoogleSwiftUI/Sources/Views/SignInWithGoogleButton.swift
@@ -20,7 +20,7 @@ extension SignInWithGoogleButton: View {
       Task {
         try await signInWithGoogle()
       }
-    }) {
+    }, label: {
       if authService.authenticationState != .authenticating {
         HStack {
           Image(systemName: "globe") // Placeholder for Google logo
@@ -46,6 +46,6 @@ extension SignInWithGoogleButton: View {
           .padding(.vertical, 8)
           .frame(maxWidth: .infinity)
       }
-    }
+    })
   }
 }

--- a/FirebaseSwiftUI/FirebaseGoogleSwiftUI/Sources/Views/SignInWithGoogleButton.swift
+++ b/FirebaseSwiftUI/FirebaseGoogleSwiftUI/Sources/Views/SignInWithGoogleButton.swift
@@ -20,7 +20,7 @@ extension SignInWithGoogleButton: View {
       Task {
         try await signInWithGoogle()
       }
-    }, label: {
+    }) {
       if authService.authenticationState != .authenticating {
         HStack {
           Image(systemName: "globe") // Placeholder for Google logo
@@ -46,7 +46,7 @@ extension SignInWithGoogleButton: View {
           .padding(.vertical, 8)
           .frame(maxWidth: .infinity)
       }
-    })
+    }
   }
 }
 

--- a/FirebaseSwiftUI/FirebaseGoogleSwiftUI/Sources/Views/SignInWithGoogleButton.swift
+++ b/FirebaseSwiftUI/FirebaseGoogleSwiftUI/Sources/Views/SignInWithGoogleButton.swift
@@ -49,3 +49,9 @@ extension SignInWithGoogleButton: View {
     })
   }
 }
+
+#Preview {
+  CommonUtils.dummyConfigurationForPreview()
+  return SignInWithGoogleButton()
+    .environment(AuthService())
+}

--- a/FirebaseSwiftUI/FirebaseGoogleSwiftUI/Sources/Views/SignInWithGoogleButton.swift
+++ b/FirebaseSwiftUI/FirebaseGoogleSwiftUI/Sources/Views/SignInWithGoogleButton.swift
@@ -1,4 +1,5 @@
 import FirebaseAuthSwiftUI
+import FirebaseCore
 import SwiftUI
 
 @MainActor
@@ -51,7 +52,7 @@ extension SignInWithGoogleButton: View {
 }
 
 #Preview {
-  CommonUtils.dummyConfigurationForPreview()
+  FirebaseOptions.dummyConfigurationForPreview()
   return SignInWithGoogleButton()
     .environment(AuthService())
 }

--- a/FirebaseSwiftUI/FirebasePhoneAuthSwiftUI/Sources/Services/PhoneAuthProviderAuthUI.swift
+++ b/FirebaseSwiftUI/FirebasePhoneAuthSwiftUI/Sources/Services/PhoneAuthProviderAuthUI.swift
@@ -3,7 +3,7 @@ import FirebaseAuthSwiftUI
 
 public typealias VerificationID = String
 
-public class PhoneAuthProviderSwift: @preconcurrency PhoneAuthProviderProtocol {
+public class PhoneAuthProviderAuthUI: @preconcurrency PhoneAuthProviderAuthUIProtocol {
   public init() {}
 
   @MainActor public func verifyPhoneNumber(phoneNumber: String) async throws -> VerificationID {

--- a/FirebaseSwiftUI/FirebasePhoneAuthSwiftUI/Sources/Views/PhoneAuthButtonView.swift
+++ b/FirebaseSwiftUI/FirebasePhoneAuthSwiftUI/Sources/Views/PhoneAuthButtonView.swift
@@ -90,3 +90,9 @@ extension PhoneAuthButtonView: View {
     Text(errorMessage).foregroundColor(.red)
   }
 }
+
+#Preview {
+  CommonUtils.dummyConfigurationForPreview()
+  return PhoneAuthButtonView()
+    .environment(AuthService())
+}

--- a/FirebaseSwiftUI/FirebasePhoneAuthSwiftUI/Sources/Views/PhoneAuthButtonView.swift
+++ b/FirebaseSwiftUI/FirebasePhoneAuthSwiftUI/Sources/Views/PhoneAuthButtonView.swift
@@ -39,11 +39,11 @@ extension PhoneAuthButtonView: View {
               )
             }
           }
-        }, label: {
+        }) {
           Text("Send SMS code")
             .padding(.vertical, 8)
             .frame(maxWidth: .infinity)
-        })
+        }
         .disabled(!PhoneUtils.isValidPhoneNumber(phoneNumber))
         .padding([.top, .bottom], 8)
         .frame(maxWidth: .infinity)
@@ -69,7 +69,7 @@ extension PhoneAuthButtonView: View {
             }
             showVerificationCodeInput = false
           }
-        }, label: {
+        }) {
           Text("Verify phone number and sign-in")
             .foregroundColor(.white)
             .padding()
@@ -77,7 +77,7 @@ extension PhoneAuthButtonView: View {
             .background(Color.green)
             .cornerRadius(8)
             .padding(.horizontal)
-        })
+        }
       }.onOpenURL { url in
         authService.auth.canHandle(url)
       }

--- a/FirebaseSwiftUI/FirebasePhoneAuthSwiftUI/Sources/Views/PhoneAuthButtonView.swift
+++ b/FirebaseSwiftUI/FirebasePhoneAuthSwiftUI/Sources/Views/PhoneAuthButtonView.swift
@@ -39,11 +39,11 @@ extension PhoneAuthButtonView: View {
               )
             }
           }
-        }) {
+        }, label: {
           Text("Send SMS code")
             .padding(.vertical, 8)
             .frame(maxWidth: .infinity)
-        }
+        })
         .disabled(!PhoneUtils.isValidPhoneNumber(phoneNumber))
         .padding([.top, .bottom], 8)
         .frame(maxWidth: .infinity)
@@ -69,7 +69,7 @@ extension PhoneAuthButtonView: View {
             }
             showVerificationCodeInput = false
           }
-        }) {
+        }, label: {
           Text("Verify phone number and sign-in")
             .foregroundColor(.white)
             .padding()
@@ -77,7 +77,7 @@ extension PhoneAuthButtonView: View {
             .background(Color.green)
             .cornerRadius(8)
             .padding(.horizontal)
-        }
+        })
       }.onOpenURL { url in
         authService.auth.canHandle(url)
       }

--- a/FirebaseSwiftUI/FirebasePhoneAuthSwiftUI/Sources/Views/PhoneAuthButtonView.swift
+++ b/FirebaseSwiftUI/FirebasePhoneAuthSwiftUI/Sources/Views/PhoneAuthButtonView.swift
@@ -1,4 +1,5 @@
 import FirebaseAuthSwiftUI
+import FirebaseCore
 import SwiftUI
 
 @MainActor
@@ -92,7 +93,7 @@ extension PhoneAuthButtonView: View {
 }
 
 #Preview {
-  CommonUtils.dummyConfigurationForPreview()
+  FirebaseOptions.dummyConfigurationForPreview()
   return PhoneAuthButtonView()
     .environment(AuthService())
 }

--- a/samples/swiftui/FirebaseSwiftUIExample/FirebaseSwiftUIExample/ContentView.swift
+++ b/samples/swiftui/FirebaseSwiftUIExample/FirebaseSwiftUIExample/ContentView.swift
@@ -16,7 +16,7 @@ struct ContentView: View {
   let authService: AuthService
 
   init() {
-    // Auth.auth().signInAnonymously()
+    Auth.auth().signInAnonymously()
 
     let actionCodeSettings = ActionCodeSettings()
     actionCodeSettings.handleCodeInApp = true

--- a/samples/swiftui/FirebaseSwiftUIExample/FirebaseSwiftUIExample/ContentView.swift
+++ b/samples/swiftui/FirebaseSwiftUIExample/FirebaseSwiftUIExample/ContentView.swift
@@ -28,8 +28,8 @@ struct ContentView: View {
       shouldAutoUpgradeAnonymousUsers: true,
       emailLinkSignInActionCodeSettings: actionCodeSettings
     )
-    let facebookProvider = FacebookProviderSwift()
-    let phoneAuthProvider = PhoneAuthProviderSwift()
+    let facebookProvider = FacebookProviderAuthUI()
+    let phoneAuthProvider = PhoneAuthProviderAuthUI()
     authService = AuthService(
       configuration: configuration,
       googleProvider: googleProvider,

--- a/samples/swiftui/FirebaseSwiftUIExample/FirebaseSwiftUIExample/ContentView.swift
+++ b/samples/swiftui/FirebaseSwiftUIExample/FirebaseSwiftUIExample/ContentView.swift
@@ -1,0 +1,48 @@
+//
+//  ContentView.swift
+//  FirebaseSwiftUIExample
+//
+//  Created by Russell Wheatley on 23/04/2025.
+//
+
+import FirebaseAuth
+import FirebaseAuthSwiftUI
+import FirebaseFacebookSwiftUI
+import FirebaseGoogleSwiftUI
+import FirebasePhoneAuthSwiftUI
+import SwiftUI
+
+struct ContentView: View {
+  let authService: AuthService
+
+  init() {
+    // Auth.auth().signInAnonymously()
+
+    let actionCodeSettings = ActionCodeSettings()
+    actionCodeSettings.handleCodeInApp = true
+    actionCodeSettings
+      .url = URL(string: "https://flutterfire-e2e-tests.firebaseapp.com")
+    actionCodeSettings.linkDomain = "flutterfire-e2e-tests.firebaseapp.com"
+    actionCodeSettings.setIOSBundleID(Bundle.main.bundleIdentifier!)
+    let configuration = AuthConfiguration(
+      shouldAutoUpgradeAnonymousUsers: true,
+      emailLinkSignInActionCodeSettings: actionCodeSettings
+    )
+    let facebookProvider = FacebookProviderSwift()
+    let phoneAuthProvider = PhoneAuthProviderSwift()
+    authService = AuthService(
+      configuration: configuration,
+      googleProvider: googleProvider,
+      facebookProvider: facebookProvider,
+      phoneAuthProvider: phoneAuthProvider
+    )
+  }
+
+  var body: some View {
+    AuthPickerView {
+      SignInWithGoogleButton()
+      SignInWithFacebookButton()
+      PhoneAuthButtonView()
+    }.environment(authService)
+  }
+}

--- a/samples/swiftui/FirebaseSwiftUIExample/FirebaseSwiftUIExample/FirebaseSwiftUIExampleApp.swift
+++ b/samples/swiftui/FirebaseSwiftUIExample/FirebaseSwiftUIExample/FirebaseSwiftUIExampleApp.swift
@@ -12,7 +12,7 @@ import Foundation
 import SwiftData
 import SwiftUI
 
-let googleProvider = GoogleProviderSwift()
+let googleProvider = GoogleProviderAuthUI()
 
 class AppDelegate: NSObject, UIApplicationDelegate {
   func application(_ application: UIApplication,

--- a/samples/swiftui/FirebaseSwiftUIExample/FirebaseSwiftUIExample/FirebaseSwiftUIExampleApp.swift
+++ b/samples/swiftui/FirebaseSwiftUIExample/FirebaseSwiftUIExample/FirebaseSwiftUIExampleApp.swift
@@ -4,14 +4,11 @@
 //
 //  Created by Russell Wheatley on 18/02/2025.
 //
-
 import FacebookCore
 import FirebaseAuth
-import FirebaseAuthSwiftUI
 import FirebaseCore
-import FirebaseFacebookSwiftUI
 import FirebaseGoogleSwiftUI
-import FirebasePhoneAuthSwiftUI
+import Foundation
 import SwiftData
 import SwiftUI
 
@@ -71,40 +68,5 @@ struct FirebaseSwiftUIExampleApp: App {
         ContentView()
       }
     }
-  }
-}
-
-struct ContentView: View {
-  let authService: AuthService
-
-  init() {
-    // Auth.auth().signInAnonymously()
-
-    let actionCodeSettings = ActionCodeSettings()
-    actionCodeSettings.handleCodeInApp = true
-    actionCodeSettings
-      .url = URL(string: "https://flutterfire-e2e-tests.firebaseapp.com")
-    actionCodeSettings.linkDomain = "flutterfire-e2e-tests.firebaseapp.com"
-    actionCodeSettings.setIOSBundleID(Bundle.main.bundleIdentifier!)
-    let configuration = AuthConfiguration(
-      shouldAutoUpgradeAnonymousUsers: true,
-      emailLinkSignInActionCodeSettings: actionCodeSettings
-    )
-    let facebookProvider = FacebookProviderSwift()
-    let phoneAuthProvider = PhoneAuthProviderSwift()
-    authService = AuthService(
-      configuration: configuration,
-      googleProvider: googleProvider,
-      facebookProvider: facebookProvider,
-      phoneAuthProvider: phoneAuthProvider
-    )
-  }
-
-  var body: some View {
-    AuthPickerView {
-      SignInWithGoogleButton()
-      SignInWithFacebookButton()
-      PhoneAuthButtonView()
-    }.environment(authService)
   }
 }


### PR DESCRIPTION
Contains the following:

1. Refactored the protocol and class names for providers so they contain `AuthUI`. Example - `FacebookProviderSwift` has changed to `FacebookProviderAuthUI`.
2. Updated Button Views with `label` argument rather than using anonymous closure.
3. Implemented `ContentView` for SwiftUI example app.
4. Created Previews for almost all Views, needed a FirebaseApp configured for a lot as we initialise FirebaseAuth in AuthService. I didn't create a preview for AuthPicker as it will be refactored soon with the implementation of View modifiers to choose authentication methods available. I will add it once that has been refactored.

Let me know what you think, @peterfriese. Just as an aside, the UI Views don't look great at the moment as we're awaiting UI design.