### PR TITLE
feat: allow user to update password

### DIFF
--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Services/AccountService+Email.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Services/AccountService+Email.swift
@@ -37,7 +37,7 @@ class EmailPasswordDeleteUserOperation: AuthenticatedOperation,
   }
 
   func callAsFunction(on user: User) async throws {
-    try await callAsFunction(on: user) { _ in
+    try await callAsFunction(on: user) {
       try await user.delete()
     }
   }
@@ -54,7 +54,7 @@ class EmailPasswordUpdatePasswordOperation: AuthenticatedOperation,
   }
 
   func callAsFunction(on user: User) async throws {
-    try await callAsFunction(on: user) { _ in
+    try await callAsFunction(on: user) {
       try await user.updatePassword(to: newPassword)
     }
   }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Services/AccountService+Email.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Services/AccountService+Email.swift
@@ -28,12 +28,35 @@ extension EmailPasswordOperationReauthentication {
   }
 }
 
-class EmailPasswordDeleteUserOperation: DeleteUserOperation,
+class EmailPasswordDeleteUserOperation: AuthenticatedOperation,
   EmailPasswordOperationReauthentication {
   let passwordPrompt: PasswordPromptCoordinator
 
   init(passwordPrompt: PasswordPromptCoordinator) {
     self.passwordPrompt = passwordPrompt
+  }
+
+  func callAsFunction(on user: User) async throws {
+    try await callAsFunction(on: user) { _ in
+      try await user.delete()
+    }
+  }
+}
+
+class EmailPasswordUpdatePasswordOperation: AuthenticatedOperation,
+  EmailPasswordOperationReauthentication {
+  let passwordPrompt: PasswordPromptCoordinator
+  let newPassword: String
+
+  init(passwordPrompt: PasswordPromptCoordinator, newPassword: String) {
+    self.passwordPrompt = passwordPrompt
+    self.newPassword = newPassword
+  }
+
+  func callAsFunction(on user: User) async throws {
+    try await callAsFunction(on: user) { _ in
+      try await user.updatePassword(to: newPassword)
+    }
   }
 }
 

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Services/AccountService.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Services/AccountService.swift
@@ -23,15 +23,15 @@ protocol AuthenticatedOperation {
 
 extension AuthenticatedOperation {
   func callAsFunction(on _: User,
-                      _ perform: (AuthenticationToken?) async throws -> Void) async throws {
+                      _ performOperation: () async throws -> Void) async throws {
     do {
-      try await perform(nil)
+      try await performOperation()
     } catch let error as NSError where error.requiresReauthentication {
       let token = try await reauthenticate()
-      try await perform(token)
+      try await performOperation()
     } catch AuthServiceError.reauthenticationRequired {
       let token = try await reauthenticate()
-      try await perform(token)
+      try await performOperation()
     }
   }
 }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Services/AuthService.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Services/AuthService.swift
@@ -29,6 +29,7 @@ public enum AuthView {
   case authPicker
   case passwordRecovery
   case emailLink
+  case updatePassword
 }
 
 @MainActor
@@ -207,6 +208,24 @@ public extension AuthService {
     do {
       if let user = auth.currentUser {
         let operation = EmailPasswordDeleteUserOperation(passwordPrompt: passwordPrompt)
+        try await operation(on: user)
+      }
+
+    } catch {
+      errorMessage = string.localizedErrorMessage(
+        for: error
+      )
+      throw error
+    }
+  }
+
+  func updatePassword(to password: String) async throws {
+    do {
+      if let user = auth.currentUser {
+        let operation = EmailPasswordUpdatePasswordOperation(
+          passwordPrompt: passwordPrompt,
+          newPassword: password
+        )
         try await operation(on: user)
       }
 

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/SignedInView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/SignedInView.swift
@@ -14,32 +14,40 @@ extension SignedInView: View {
   }
 
   public var body: some View {
-    VStack {
-      Text("Signed in")
-      Text("User: \(authService.currentUser?.email ?? "Unknown")")
+    if authService.authView == .updatePassword {
+      UpdatePasswordView()
+    } else {
+      VStack {
+        Text("Signed in")
+        Text("User: \(authService.currentUser?.email ?? "Unknown")")
 
-      if authService.currentUser?.isEmailVerified == false {
-        VerifyEmailView()
-      }
-
-      Button("Sign out") {
-        Task {
-          do {
-            try await authService.signOut()
-          } catch {}
+        if authService.currentUser?.isEmailVerified == false {
+          VerifyEmailView()
         }
-      }
-      Divider()
-      Button("Delete account") {
-        Task {
-          do {
-            try await authService.deleteUser()
-          } catch {}
+        Divider()
+        Button("Update password") {
+          authService.authView = .updatePassword
         }
+        Divider()
+        Button("Sign out") {
+          Task {
+            do {
+              try await authService.signOut()
+            } catch {}
+          }
+        }
+        Divider()
+        Button("Delete account") {
+          Task {
+            do {
+              try await authService.deleteUser()
+            } catch {}
+          }
+        }
+        Text(authService.errorMessage).foregroundColor(.red)
+      }.sheet(isPresented: isShowingPasswordPrompt) {
+        PasswordPromptSheet(coordinator: authService.passwordPrompt)
       }
-      Text(authService.errorMessage).foregroundColor(.red)
-    }.sheet(isPresented: isShowingPasswordPrompt) {
-      PasswordPromptSheet(coordinator: authService.passwordPrompt)
     }
   }
 }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/UpdatePassword.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/UpdatePassword.swift
@@ -1,0 +1,75 @@
+//
+//  UpdatePassword.swift
+//  FirebaseUI
+//
+//  Created by Russell Wheatley on 24/04/2025.
+//
+
+import SwiftUI
+
+private enum FocusableField: Hashable {
+  case password
+  case confirmPassword
+}
+
+public struct UpdatePasswordView {
+  @Environment(AuthService.self) private var authService
+  @State private var password = ""
+  @State private var confirmPassword = ""
+
+  @FocusState private var focus: FocusableField?
+  private var isValid: Bool {
+    !password.isEmpty && password == confirmPassword
+  }
+}
+
+extension UpdatePasswordView: View {
+  public var body: some View {
+    VStack {
+      LabeledContent {
+        SecureField("Password", text: $password)
+          .focused($focus, equals: .password)
+          .submitLabel(.go)
+      } label: {
+        Image(systemName: "lock")
+      }
+      .padding(.vertical, 6)
+      .background(Divider(), alignment: .bottom)
+      .padding(.bottom, 8)
+      Divider()
+
+      LabeledContent {
+        SecureField("Confirm password", text: $confirmPassword)
+          .focused($focus, equals: .confirmPassword)
+          .submitLabel(.go)
+      } label: {
+        Image(systemName: "lock")
+      }
+      .padding(.vertical, 6)
+      .background(Divider(), alignment: .bottom)
+      .padding(.bottom, 8)
+      Divider()
+      Button(action: {
+        Task {
+          try await authService.updatePassword(to: confirmPassword)
+          authService.authView = .authPicker
+        }
+      }) {
+        if authService.authenticationState != .authenticating {
+          Text("Update password")
+            .padding(.vertical, 8)
+            .frame(maxWidth: .infinity)
+        } else {
+          ProgressView()
+            .progressViewStyle(CircularProgressViewStyle(tint: .white))
+            .padding(.vertical, 8)
+            .frame(maxWidth: .infinity)
+        }
+      }
+      .disabled(!isValid)
+      .padding([.top, .bottom], 8)
+      .frame(maxWidth: .infinity)
+      .buttonStyle(.borderedProminent)
+    }
+  }
+}

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/UpdatePassword.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/UpdatePassword.swift
@@ -12,6 +12,7 @@ private enum FocusableField: Hashable {
   case confirmPassword
 }
 
+@MainActor
 public struct UpdatePasswordView {
   @Environment(AuthService.self) private var authService
   @State private var password = ""
@@ -24,6 +25,13 @@ public struct UpdatePasswordView {
 }
 
 extension UpdatePasswordView: View {
+  private var isShowingPasswordPrompt: Binding<Bool> {
+    Binding(
+      get: { authService.passwordPrompt.isPromptingPassword },
+      set: { authService.passwordPrompt.isPromptingPassword = $0 }
+    )
+  }
+
   public var body: some View {
     VStack {
       LabeledContent {
@@ -70,6 +78,8 @@ extension UpdatePasswordView: View {
       .padding([.top, .bottom], 8)
       .frame(maxWidth: .infinity)
       .buttonStyle(.borderedProminent)
+    }.sheet(isPresented: isShowingPasswordPrompt) {
+      PasswordPromptSheet(coordinator: authService.passwordPrompt)
     }
   }
 }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/UpdatePassword.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/UpdatePassword.swift
@@ -44,6 +44,7 @@ extension UpdatePasswordView: View {
       .padding(.vertical, 6)
       .background(Divider(), alignment: .bottom)
       .padding(.bottom, 8)
+
       Divider()
 
       LabeledContent {
@@ -56,24 +57,20 @@ extension UpdatePasswordView: View {
       .padding(.vertical, 6)
       .background(Divider(), alignment: .bottom)
       .padding(.bottom, 8)
+
       Divider()
+
       Button(action: {
         Task {
           try await authService.updatePassword(to: confirmPassword)
           authService.authView = .authPicker
         }
-      }) {
-        if authService.authenticationState != .authenticating {
-          Text("Update password")
-            .padding(.vertical, 8)
-            .frame(maxWidth: .infinity)
-        } else {
-          ProgressView()
-            .progressViewStyle(CircularProgressViewStyle(tint: .white))
-            .padding(.vertical, 8)
-            .frame(maxWidth: .infinity)
-        }
-      }
+      }, label: {
+        Text("Update password")
+          .padding(.vertical, 8)
+          .frame(maxWidth: .infinity)
+
+      })
       .disabled(!isValid)
       .padding([.top, .bottom], 8)
       .frame(maxWidth: .infinity)


### PR DESCRIPTION
1. refactored the logic for re-authentication by using a callback which allows passing in new password. The delete user/update password operations now share re-authentication logic.
2. Created a View (UI is functional - not finalised until we have design) with password prompt (if needed for re-authentication).
3. Will add a Preview for the View once [this PR has been reviewed/merged](https://github.com/firebase/FirebaseUI-iOS/pull/1244) as it contains logic needed to preview. 