### PR TITLE
feat: utilise string localisations

### DIFF
--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Strings/Localizable.xcstrings
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Strings/Localizable.xcstrings
@@ -394,13 +394,25 @@
       }
     },
     "EmailLinkSignInLabel" : {
-      "comment" : "Button label for email link sign-in",
+      "comment" : "Button label to push user to email link sign-in",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Prefer Email link sign-in?"
+          }
+        }
+      }
+    },
+    "EmailLinkSignInTitle" : {
+      "comment" : "Sign in with email link View title",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign in with email link"
           }
         }
       }
@@ -542,9 +554,6 @@
           }
         }
       }
-    },
-    "Key" : {
-      "extractionState" : "manual"
     },
     "Log in" : {
 
@@ -842,6 +851,18 @@
     },
     "Send email sign-in link" : {
 
+    },
+    "SendEmailSignInLinkButtonLabel" : {
+      "comment" : "Button label for sending email sign-in link",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send email sign-in link"
+          }
+        }
+      }
     },
     "Sign in with email link" : {
 

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Strings/Localizable.xcstrings
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Strings/Localizable.xcstrings
@@ -1,6 +1,9 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "%@" : {
+
+    },
     "AccountDisabledError" : {
       "comment" : "Error message displayed when the account is disabled. Use short/abbreviated translation for 'email' which is less than 15 chars.",
       "extractionState" : "migrated",
@@ -235,6 +238,9 @@
         }
       }
     },
+    "Confirm password" : {
+
+    },
     "ConfirmEmail" : {
       "comment" : "Title of confirm email label.",
       "extractionState" : "manual",
@@ -270,9 +276,6 @@
           }
         }
       }
-    },
-    "Delete account" : {
-
     },
     "DeleteAccountBody" : {
       "comment" : "Alert message body shown to confirm account deletion action.",
@@ -436,9 +439,6 @@
         }
       }
     },
-    "Enter Password" : {
-
-    },
     "EnterYourEmail" : {
       "comment" : "Title for email entry screen, email text field placeholder. Use short/abbreviated translation for 'email' which is less than 15 chars.",
       "extractionState" : "manual",
@@ -591,6 +591,9 @@
           }
         }
       }
+    },
+    "Password" : {
+
     },
     "PasswordRecoveryEmailSentMessage" : {
       "comment" : "Message displayed when the email for password recovery has been sent.",
@@ -847,9 +850,6 @@
         }
       }
     },
-    "Sign out" : {
-
-    },
     "Sign up" : {
 
     },
@@ -948,9 +948,6 @@
           }
         }
       }
-    },
-    "Submit" : {
-
     },
     "TermsOfService" : {
       "comment" : "Text linked to a web page with the Terms of Service content.",
@@ -1060,6 +1057,17 @@
         }
       }
     },
+    "Update password" : {
+      "comment" : "Update password button label",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Update password"
+          }
+        }
+      }
+    },
     "UpdateEmailAlertMessage" : {
       "comment" : "Alert action message shown before updating email action. Use short/abbreviated translation for 'email' which is less than 15 chars.",
       "extractionState" : "manual",
@@ -1084,9 +1092,6 @@
         }
       }
     },
-    "User: %@" : {
-
-    },
     "UserNotFoundError" : {
       "comment" : "Error message displayed when there's no account matching the email address. Use short/abbreviated translation for 'email' which is less than 15 chars.",
       "extractionState" : "migrated",
@@ -1100,7 +1105,15 @@
       }
     },
     "Verify email address?" : {
-
+      "comment" : "Label for sending email verification to user.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verify email address?"
+          }
+        }
+      }
     },
     "VerifyItsYou" : {
       "comment" : "Alert message title show for re-authorization.",

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Strings/Localizable.xcstrings
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Strings/Localizable.xcstrings
@@ -329,7 +329,14 @@
 
     },
     "Don't have an account yet?" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Don't have an account yet?"
+          }
+        }
+      }
     },
     "EditEmailTitle" : {
       "comment" : "Controller title shown when editing account email. Use short/abbreviated translation for 'email' which is less than 15 chars.",
@@ -554,7 +561,14 @@
 
     },
     "Login" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Login"
+          }
+        }
+      }
     },
     "Name" : {
       "comment" : "Label next to a name text field.",

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Strings/Localizable.xcstrings
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Strings/Localizable.xcstrings
@@ -234,9 +234,6 @@
         }
       }
     },
-    "Confirm password" : {
-
-    },
     "ConfirmEmail" : {
       "comment" : "Title of confirm email label.",
       "extractionState" : "manual",
@@ -377,9 +374,6 @@
           }
         }
       }
-    },
-    "Email" : {
-      "comment" : "Label next to a email text field. Use short/abbreviated translation for 'email' which is less than 15 chars."
     },
     "EmailAlreadyInUseError" : {
       "comment" : "Error message displayed when the email address is already in use. Use short/abbreviated translation for 'email' which is less than 15 chars.",
@@ -558,9 +552,6 @@
     "Log in" : {
 
     },
-    "Log in with password" : {
-
-    },
     "Login" : {
 
     },
@@ -720,13 +711,7 @@
         }
       }
     },
-    "Please check your email for email sign-in link." : {
-
-    },
     "Please check your email for verification link." : {
-
-    },
-    "Prefer Email link sign-in?" : {
 
     },
     "PrivacyPolicy" : {
@@ -849,9 +834,6 @@
         }
       }
     },
-    "Send email sign-in link" : {
-
-    },
     "SendEmailSignInLinkButtonLabel" : {
       "comment" : "Button label for sending email sign-in link",
       "extractionState" : "manual",
@@ -863,9 +845,6 @@
           }
         }
       }
-    },
-    "Sign in with email link" : {
-
     },
     "Sign out" : {
 

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Strings/Localizable.xcstrings
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Strings/Localizable.xcstrings
@@ -249,6 +249,18 @@
         }
       }
     },
+    "ConfirmPasswordInputLabel" : {
+      "comment" : "Input label for confirming password when signing up",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirm Password"
+          }
+        }
+      }
+    },
     "Delete" : {
       "comment" : "Text of Delete action button.",
       "extractionState" : "manual",
@@ -381,6 +393,18 @@
         }
       }
     },
+    "EmailLinkSignInLabel" : {
+      "comment" : "Button label for email link sign-in",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prefer Email link sign-in?"
+          }
+        }
+      }
+    },
     "EmailsDontMatch" : {
       "comment" : "Error message displayed when after re-authorization current user's email and re-authorized user's email doesn't match. Use short/abbreviated translation for 'email' which is less than 15 chars.",
       "extractionState" : "manual",
@@ -404,6 +428,9 @@
           }
         }
       }
+    },
+    "Enter Password" : {
+
     },
     "EnterYourEmail" : {
       "comment" : "Title for email entry screen, email text field placeholder. Use short/abbreviated translation for 'email' which is less than 15 chars.",
@@ -489,9 +516,6 @@
         }
       }
     },
-    "Forgotten Password?" : {
-
-    },
     "Instructions" : {
 
     },
@@ -518,6 +542,9 @@
           }
         }
       }
+    },
+    "Key" : {
+      "extractionState" : "manual"
     },
     "Log in" : {
 
@@ -563,12 +590,6 @@
           }
         }
       }
-    },
-    "Password" : {
-      "comment" : "Label next to a password text field."
-    },
-    "Password Recovery" : {
-
     },
     "PasswordRecoveryEmailSentMessage" : {
       "comment" : "Message displayed when the email for password recovery has been sent.",
@@ -691,9 +712,6 @@
       }
     },
     "Please check your email for email sign-in link." : {
-
-    },
-    "Please check your email for password recovery instructions." : {
 
     },
     "Please check your email for verification link." : {
@@ -834,9 +852,6 @@
     "Sign up" : {
 
     },
-    "Signed in" : {
-
-    },
     "SignedIn" : {
       "comment" : "Title of successfully signed in label.",
       "extractionState" : "manual",
@@ -932,6 +947,9 @@
           }
         }
       }
+    },
+    "Submit" : {
+
     },
     "TermsOfService" : {
       "comment" : "Text linked to a web page with the Terms of Service content.",

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
@@ -1,15 +1,30 @@
 import FirebaseAuth
 import SwiftUI
 
+// Auth Picker (not signed-in)
 let kAuthPickerTitle = "AuthPickerTitle"
 
+// Used across multiple Views
 let kEnterYourEmail = "EnterYourEmail"
 let kEnterYourPassword = "EnterYourPassword"
+let kOK = "OK"
+let kBack = "Back"
 
+// Signed-in
 let kSignedInTitle = "SignedIn"
+
+let kForgotPasswordButtonLabel = "ForgotPasswordTitle"
+let kForgotPasswordInputLabel = "ForgotPassword"
+
+// Password recovery
+let kPasswordRecoveryTitle = "PasswordRecoveryTitle"
+let kPasswordRecoveryEmailSentTitle = "PasswordRecoveryEmailSentTitle"
+let kPasswordRecoveryMessage = "PasswordRecoveryMessage"
+let kPasswordRecoveryEmailSentMessage = "PasswordRecoveryEmailSentMessage"
 
 let kKeyNotFound = "Key not found"
 
+// Errors
 let kUsersNotFoundError = "UserNotFoundError"
 let kEmailAlreadyInUseError = "EmailAlreadyInUseError"
 let kInvalidEmailError = "InvalidEmailError"

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
@@ -301,4 +301,30 @@ public class StringUtils {
   public var facebookAuthorizeUserTrackingMessage: String {
     return localizedString(for: "For classic Facebook login, please authorize user tracking.")
   }
+
+  /// Phone provider
+  /// found in:
+  /// - PhoneAuthButtonView
+  public var enterPhoneNumberLabel: String {
+    return localizedString(for: "Enter phone number")
+  }
+  /// Phone provider
+  /// found in:
+  /// - PhoneAuthButtonView
+  public var phoneNumberVerificationCodeLabel: String {
+    return localizedString(for: "Enter verification code")
+  }
+  /// Phone provider
+  /// found in:
+  /// - PhoneAuthButtonView
+  public var smsCodeSentLabel: String {
+    return localizedString(for: "SMS code sent")
+  }
+
+  /// Phone provider
+  /// found in:
+  /// - PhoneAuthButtonView
+  public var verifyPhoneNumberAndSignInLabel: String {
+    return localizedString(for: "Verify phone number and sign-in")
+  }
 }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
@@ -130,6 +130,34 @@ public class StringUtils {
     return localizedString(for: "SignedIn")
   }
 
+  /// Confirm password
+  /// found in:
+  /// - EmailAuthView
+  public var confirmPasswordInputLabel: String {
+    return localizedString(for: "ConfirmPasswordInputLabel")
+  }
+
+  /// Sign in with email button label or can be used as title
+  /// found in:
+  /// EmailAuthView
+  public var signInWithEmailButtonLabel: String {
+    return localizedString(for: "SignInWithEmail")
+  }
+
+  /// Sign up with email button label
+  /// found in:
+  /// - EmailAuthView
+  public var signUpWithEmailButtonLabel: String {
+    return localizedString(for: "SignUpTitle")
+  }
+
+  /// Sign up with email link button label
+  /// found in:
+  /// - EmailAuthView
+  public var signUpWithEmailLinkButtonLabel: String {
+    return localizedString(for: "EmailLinkSignInLabel")
+  }
+
   /// General string - Back button label
   /// found in:
   /// - PasswordRecoveryView

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
@@ -1,6 +1,13 @@
 import FirebaseAuth
 import SwiftUI
 
+let kAuthPickerTitle = "AuthPickerTitle"
+
+let kEnterYourEmail = "EnterYourEmail"
+let kEnterYourPassword = "EnterYourPassword"
+
+let kSignedInTitle = "SignedIn"
+
 let kKeyNotFound = "Key not found"
 
 let kUsersNotFoundError = "UserNotFoundError"
@@ -19,7 +26,7 @@ public class StringUtils {
     self.bundle = bundle
   }
 
-  public func localizedString(forKey key: String) -> String {
+  public func localizedString(for key: String) -> String {
     let keyLocale = String.LocalizationValue(key)
     let value = String(localized: keyLocale, bundle: bundle)
     return value
@@ -31,27 +38,27 @@ public class StringUtils {
     switch errorCode {
     case .emailAlreadyInUse:
       return localizedString(
-        forKey: kEmailAlreadyInUseError
+        for: kEmailAlreadyInUseError
       )
     case .invalidEmail:
-      return localizedString(forKey: kInvalidEmailError)
+      return localizedString(for: kInvalidEmailError)
     case .weakPassword:
-      return localizedString(forKey: kWeakPasswordError)
+      return localizedString(for: kWeakPasswordError)
     case .tooManyRequests:
       return localizedString(
-        forKey: kSignUpTooManyTimesError
+        for: kSignUpTooManyTimesError
       )
     case .wrongPassword:
       return localizedString(
-        forKey: kWrongPasswordError
+        for: kWrongPasswordError
       )
     case .userNotFound:
       return localizedString(
-        forKey: kUsersNotFoundError
+        for: kUsersNotFoundError
       )
     case .userDisabled:
       return localizedString(
-        forKey: kAccountDisabledError
+        for: kAccountDisabledError
       )
     default:
       return error.localizedDescription

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
@@ -1,27 +1,6 @@
 import FirebaseAuth
 import SwiftUI
 
-// Auth Picker (not signed-in)
-let kAuthPickerTitle = "AuthPickerTitle"
-
-// Used across multiple Views
-let kEnterYourEmail = "EnterYourEmail"
-let kEnterYourPassword = "EnterYourPassword"
-let kOK = "OK"
-let kBack = "Back"
-
-// Signed-in
-let kSignedInTitle = "SignedIn"
-
-let kForgotPasswordButtonLabel = "ForgotPasswordTitle"
-let kForgotPasswordInputLabel = "ForgotPassword"
-
-// Password recovery
-let kPasswordRecoveryTitle = "PasswordRecoveryTitle"
-let kPasswordRecoveryEmailSentTitle = "PasswordRecoveryEmailSentTitle"
-let kPasswordRecoveryMessage = "PasswordRecoveryMessage"
-let kPasswordRecoveryEmailSentMessage = "PasswordRecoveryEmailSentMessage"
-
 let kKeyNotFound = "Key not found"
 
 // Errors
@@ -84,7 +63,7 @@ public class StringUtils {
   /// found in:
   /// - AuthPickerView
   public var authPickerTitle: String {
-    return localizedString(for: kAuthPickerTitle)
+    return localizedString(for: "AuthPickerTitle")
   }
 
   /// Email input label
@@ -92,76 +71,76 @@ public class StringUtils {
   /// - EmailAuthView
   /// - PasswordRecoveryView
   public var emailInputLabel: String {
-    return localizedString(for: kEnterYourEmail)
+    return localizedString(for: "EnterYourEmail")
   }
 
   /// Password button action label
   /// found in:
   /// - EmailAuthView
   public var passwordButtonLabel: String {
-    return localizedString(for: kForgotPasswordButtonLabel)
+    return localizedString(for: "ForgotPasswordTitle")
   }
 
   /// Password input label
   /// found in:
   /// - EmailAuthView
   public var passwordInputLabel: String {
-    return localizedString(for: kEnterYourPassword)
+    return localizedString(for: "EnterYourPassword")
   }
 
   /// Password recovery title
   /// found in:
   /// - PasswordRecoveryView
   public var passwordRecoveryTitle: String {
-    return localizedString(for: kPasswordRecoveryTitle)
+    return localizedString(for: "PasswordRecoveryTitle")
   }
 
   /// Password recovery email sent title
   /// found in:
   /// - PasswordRecoveryView
   public var passwordRecoveryEmailSentTitle: String {
-    return localizedString(for: kPasswordRecoveryEmailSentTitle)
+    return localizedString(for: "PasswordRecoveryEmailSentTitle")
   }
 
   /// Password recovery helper message
   /// found in:
   /// - PasswordRecoveryView
   public var passwordRecoveryHelperMessage: String {
-    return localizedString(for: kPasswordRecoveryMessage)
+    return localizedString(for: "PasswordRecoveryMessage")
   }
 
   /// Password recovery email sent message
   /// found in:
   /// - PasswordRecoveryView
   public var passwordRecoveryEmailSentMessage: String {
-    return localizedString(for: kPasswordRecoveryEmailSentMessage)
+    return localizedString(for: "PasswordRecoveryEmailSentMessage")
   }
 
   /// Forgot password input label
   /// found in:
   /// - PasswordRecoveryView
   public var forgotPasswordInputLabel: String {
-    return localizedString(for: kForgotPasswordInputLabel)
+    return localizedString(for: "ForgotPassword")
   }
 
   /// Signed in title
   /// found in:
   /// - SignedInView
   public var signedInTitle: String {
-    return localizedString(for: kSignedInTitle)
+    return localizedString(for: "SignedIn")
   }
 
   /// General string - Back button label
   /// found in:
   /// - PasswordRecoveryView
   public var backButtonLabel: String {
-    return localizedString(for: kBack)
+    return localizedString(for: "Back")
   }
 
   /// General string - OK button label
   /// found in:
   /// - PasswordRecoveryView
   public var okButtonLabel: String {
-    return localizedString(for: kOK)
+    return localizedString(for: "OK")
   }
 }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
@@ -85,6 +85,7 @@ public class StringUtils {
   /// Password input label
   /// found in:
   /// - EmailAuthView
+  /// - PasswordPromptView
   public var passwordInputLabel: String {
     return localizedString(for: "EnterYourPassword")
   }
@@ -192,7 +193,15 @@ public class StringUtils {
   /// found in:
   /// - PasswordRecoveryView
   /// - EmailLinkView
+  /// - PasswordPromptView
   public var okButtonLabel: String {
     return localizedString(for: "OK")
+  }
+
+  /// General string - Cancel button label
+  /// found in:
+  /// - PasswordPromptView
+  public var cancelButtonLabel: String {
+    return localizedString(for: "Cancel")
   }
 }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
@@ -79,4 +79,89 @@ public class StringUtils {
       return error.localizedDescription
     }
   }
+
+  /// Auth Picker title
+  /// found in:
+  /// - AuthPickerView
+  public var authPickerTitle: String {
+    return localizedString(for: kAuthPickerTitle)
+  }
+
+  /// Email input label
+  /// found in:
+  /// - EmailAuthView
+  /// - PasswordRecoveryView
+  public var emailInputLabel: String {
+    return localizedString(for: kEnterYourEmail)
+  }
+
+  /// Password button action label
+  /// found in:
+  /// - EmailAuthView
+  public var passwordButtonLabel: String {
+    return localizedString(for: kForgotPasswordButtonLabel)
+  }
+
+  /// Password input label
+  /// found in:
+  /// - EmailAuthView
+  public var passwordInputLabel: String {
+    return localizedString(for: kEnterYourPassword)
+  }
+
+  /// Password recovery title
+  /// found in:
+  /// - PasswordRecoveryView
+  public var passwordRecoveryTitle: String {
+    return localizedString(for: kPasswordRecoveryTitle)
+  }
+
+  /// Password recovery email sent title
+  /// found in:
+  /// - PasswordRecoveryView
+  public var passwordRecoveryEmailSentTitle: String {
+    return localizedString(for: kPasswordRecoveryEmailSentTitle)
+  }
+
+  /// Password recovery helper message
+  /// found in:
+  /// - PasswordRecoveryView
+  public var passwordRecoveryHelperMessage: String {
+    return localizedString(for: kPasswordRecoveryMessage)
+  }
+
+  /// Password recovery email sent message
+  /// found in:
+  /// - PasswordRecoveryView
+  public var passwordRecoveryEmailSentMessage: String {
+    return localizedString(for: kPasswordRecoveryEmailSentMessage)
+  }
+
+  /// Forgot password input label
+  /// found in:
+  /// - PasswordRecoveryView
+  public var forgotPasswordInputLabel: String {
+    return localizedString(for: kForgotPasswordInputLabel)
+  }
+
+  /// Signed in title
+  /// found in:
+  /// - SignedInView
+  public var signedInTitle: String {
+    return localizedString(for: kSignedInTitle)
+  }
+
+  /// General string - Back button label
+  /// found in:
+  /// - PasswordRecoveryView
+  public var backButtonLabel: String {
+    return localizedString(for: kBack)
+  }
+
+  /// General string - OK button label
+  /// found in:
+  /// - PasswordRecoveryView
+  public var okButtonLabel: String {
+    return localizedString(for: kOK)
+  }
 }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
@@ -201,6 +201,14 @@ public class StringUtils {
   public var signOutButtonLabel: String {
     return localizedString(for: "AS_SignOut")
   }
+  
+  /// Account settings - update password button label
+  /// found in:
+  /// SignedInView
+  public var updatePasswordButtonLabel: String {
+    return localizedString(for: "Update password")
+  }
+  
 
   /// General string - Back button label
   /// found in:

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
@@ -3,7 +3,6 @@ import SwiftUI
 
 let kKeyNotFound = "Key not found"
 
-
 public class StringUtils {
   let bundle: Bundle
   init(bundle: Bundle) {
@@ -17,37 +16,37 @@ public class StringUtils {
   }
 
   public func localizedErrorMessage(for error: Error) -> String {
-      let authError = error as NSError
-      let errorCode = AuthErrorCode(rawValue: authError.code)
-      switch errorCode {
-      case .emailAlreadyInUse:
-        return localizedString(
-          for: "EmailAlreadyInUseError"
-        )
-      case .invalidEmail:
-        return localizedString(for: "InvalidEmailError")
-      case .weakPassword:
-        return localizedString(for: "WeakPasswordError")
-      case .tooManyRequests:
-        return localizedString(
-          for: "SignUpTooManyTimesError"
-        )
-      case .wrongPassword:
-        return localizedString(
-          for: "WrongPasswordError"
-        )
-      case .userNotFound:
-        return localizedString(
-          for: "UserNotFoundError"
-        )
-      case .userDisabled:
-        return localizedString(
-          for: "AccountDisabledError"
-        )
-      default:
-        return error.localizedDescription
-      }
+    let authError = error as NSError
+    let errorCode = AuthErrorCode(rawValue: authError.code)
+    switch errorCode {
+    case .emailAlreadyInUse:
+      return localizedString(
+        for: "EmailAlreadyInUseError"
+      )
+    case .invalidEmail:
+      return localizedString(for: "InvalidEmailError")
+    case .weakPassword:
+      return localizedString(for: "WeakPasswordError")
+    case .tooManyRequests:
+      return localizedString(
+        for: "SignUpTooManyTimesError"
+      )
+    case .wrongPassword:
+      return localizedString(
+        for: "WrongPasswordError"
+      )
+    case .userNotFound:
+      return localizedString(
+        for: "UserNotFoundError"
+      )
+    case .userDisabled:
+      return localizedString(
+        for: "AccountDisabledError"
+      )
+    default:
+      return error.localizedDescription
     }
+  }
 
   /// Auth Picker title
   /// found in:
@@ -191,7 +190,7 @@ public class StringUtils {
   public var signOutButtonLabel: String {
     return localizedString(for: "AS_SignOut")
   }
-  
+
   /// Account settings - update password button label
   /// found in:
   /// SignedInView
@@ -212,7 +211,6 @@ public class StringUtils {
   public var verifyEmailSheetMessage: String {
     return localizedString(for: "Verification email sent")
   }
-  
 
   /// General string - Back button label
   /// found in:
@@ -236,5 +234,40 @@ public class StringUtils {
   /// - PasswordPromptView
   public var cancelButtonLabel: String {
     return localizedString(for: "Cancel")
+  }
+
+  /// Facebook provider
+  /// found in:
+  /// - SignInWithFacebookButton
+  public var facebookLoginButtonLabel: String {
+    return localizedString(for: "Continue with Facebook")
+  }
+
+  /// Facebook provider
+  /// found in:
+  /// - SignInWithFacebookButton
+  public var facebookLoginCancelledLabel: String {
+    return localizedString(for: "Facebook login cancelled")
+  }
+
+  /// Facebook provider
+  /// found in:
+  /// - SignInWithFacebookButton
+  public var authorizeUserTrackingLabel: String {
+    return localizedString(for: "Authorize User Tracking")
+  }
+
+  /// Facebook provider
+  /// found in:
+  /// - SignInWithFacebookButton
+  public var facebookLimitedLoginLabel: String {
+    return localizedString(for: "Limited Login")
+  }
+
+  /// Facebook provider
+  /// found in:
+  /// - SignInWithFacebookButton
+  public var facebookAuthorizeUserTrackingMessage: String {
+    return localizedString(for: "For classic Facebook login, please authorize user tracking.")
   }
 }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
@@ -70,6 +70,7 @@ public class StringUtils {
   /// found in:
   /// - EmailAuthView
   /// - PasswordRecoveryView
+  /// - EmailLinkView
   public var emailInputLabel: String {
     return localizedString(for: "EnterYourEmail")
   }
@@ -139,7 +140,7 @@ public class StringUtils {
 
   /// Sign in with email button label or can be used as title
   /// found in:
-  /// EmailAuthView
+  /// - EmailAuthView
   public var signInWithEmailButtonLabel: String {
     return localizedString(for: "SignInWithEmail")
   }
@@ -151,16 +152,38 @@ public class StringUtils {
     return localizedString(for: "SignUpTitle")
   }
 
-  /// Sign up with email link button label
+  /// Sign-in with email link button label to push user to email link view
   /// found in:
   /// - EmailAuthView
   public var signUpWithEmailLinkButtonLabel: String {
     return localizedString(for: "EmailLinkSignInLabel")
   }
 
+  /// send email link sign-in button label
+  /// found in:
+  /// - EmailLinkView
+  public var sendEmailLinkButtonLabel: String {
+    return localizedString(for: "SendEmailSignInLinkButtonLabel")
+  }
+
+  /// Sign in with email link View title
+  /// found in:
+  /// - EmailLinkView
+  public var signInWithEmailLinkViewTitle: String {
+    return localizedString(for: "EmailLinkSignInTitle")
+  }
+
+  /// Sign in with email link View message
+  /// found in:
+  /// - EmailLinkView
+  public var signInWithEmailLinkViewMessage: String {
+    return localizedString(for: "SignInEmailSent")
+  }
+
   /// General string - Back button label
   /// found in:
   /// - PasswordRecoveryView
+  /// - EmailLinkView
   public var backButtonLabel: String {
     return localizedString(for: "Back")
   }
@@ -168,6 +191,7 @@ public class StringUtils {
   /// General string - OK button label
   /// found in:
   /// - PasswordRecoveryView
+  /// - EmailLinkView
   public var okButtonLabel: String {
     return localizedString(for: "OK")
   }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
@@ -181,6 +181,27 @@ public class StringUtils {
     return localizedString(for: "SignInEmailSent")
   }
 
+  /// Account settings - Delete button label
+  /// found in:
+  /// - SignedInView
+  public var deleteAccountButtonLabel: String {
+    return localizedString(for: "AS_DeleteAccount")
+  }
+
+  /// Account settings - Email label
+  /// found in:
+  /// SignedInView
+  public var accountSettingsEmailLabel: String {
+    return localizedString(for: "AS_Email")
+  }
+
+  /// Account settings - sign out button label
+  /// found in:
+  /// - SignedInView
+  public var signOutButtonLabel: String {
+    return localizedString(for: "AS_SignOut")
+  }
+
   /// General string - Back button label
   /// found in:
   /// - PasswordRecoveryView

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
@@ -236,6 +236,34 @@ public class StringUtils {
     return localizedString(for: "Cancel")
   }
 
+  /// Email provider
+  /// found in:
+  /// - AuthPickerView
+  public var emailLoginFlowLabel: String {
+    return localizedString(for: "Login")
+  }
+
+  /// Email provider
+  /// found in:
+  /// - AuthPickerView
+  public var emailSignUpFlowLabel: String {
+    return localizedString(for: "Sign up")
+  }
+
+  /// Email provider
+  /// found in:
+  /// - AuthPickerView
+  public var dontHaveAnAccountYetLabel: String {
+    return localizedString(for: "Don't have an account yet?")
+  }
+
+  /// Email provider
+  /// found in:
+  /// - AuthPickerView
+  public var alreadyHaveAnAccountLabel: String {
+    return localizedString(for: "Already have an account?")
+  }
+
   /// Facebook provider
   /// found in:
   /// - SignInWithFacebookButton

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
@@ -198,6 +198,20 @@ public class StringUtils {
   public var updatePasswordButtonLabel: String {
     return localizedString(for: "Update password")
   }
+
+  /// Account settings - send email verification label
+  /// found in:
+  /// VerifyEmailView
+  public var sendEmailVerificationButtonLabel: String {
+    return localizedString(for: "Verify email address?")
+  }
+
+  /// Account settings - verify email sheet message
+  /// found in:
+  /// VerifyEmailView
+  public var verifyEmailSheetMessage: String {
+    return localizedString(for: "Verification email sent")
+  }
   
 
   /// General string - Back button label

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
@@ -75,6 +75,7 @@ public class StringUtils {
   /// found in:
   /// - EmailAuthView
   /// - PasswordPromptView
+  /// - UpdatePassword
   public var passwordInputLabel: String {
     return localizedString(for: "EnterYourPassword")
   }
@@ -124,6 +125,7 @@ public class StringUtils {
   /// Confirm password
   /// found in:
   /// - EmailAuthView
+  /// - UpdatePassword
   public var confirmPasswordInputLabel: String {
     return localizedString(for: "ConfirmPasswordInputLabel")
   }
@@ -193,7 +195,8 @@ public class StringUtils {
 
   /// Account settings - update password button label
   /// found in:
-  /// SignedInView
+  /// - SignedInView
+  /// - UpdatePassword
   public var updatePasswordButtonLabel: String {
     return localizedString(for: "Update password")
   }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Utils/StringUtils.swift
@@ -3,16 +3,6 @@ import SwiftUI
 
 let kKeyNotFound = "Key not found"
 
-// Errors
-let kUsersNotFoundError = "UserNotFoundError"
-let kEmailAlreadyInUseError = "EmailAlreadyInUseError"
-let kInvalidEmailError = "InvalidEmailError"
-let kWeakPasswordError = "WeakPasswordError"
-let kSignUpTooManyTimesError = "SignUpTooManyTimesError"
-let kWrongPasswordError = "WrongPasswordError"
-let kAccountDisabledError = "AccountDisabledError"
-let kEmailsDoNotMatchError = "EmailsDoNotMatchError"
-let kUnknownError = "UnknownError"
 
 public class StringUtils {
   let bundle: Bundle
@@ -27,37 +17,37 @@ public class StringUtils {
   }
 
   public func localizedErrorMessage(for error: Error) -> String {
-    let authError = error as NSError
-    let errorCode = AuthErrorCode(rawValue: authError.code)
-    switch errorCode {
-    case .emailAlreadyInUse:
-      return localizedString(
-        for: kEmailAlreadyInUseError
-      )
-    case .invalidEmail:
-      return localizedString(for: kInvalidEmailError)
-    case .weakPassword:
-      return localizedString(for: kWeakPasswordError)
-    case .tooManyRequests:
-      return localizedString(
-        for: kSignUpTooManyTimesError
-      )
-    case .wrongPassword:
-      return localizedString(
-        for: kWrongPasswordError
-      )
-    case .userNotFound:
-      return localizedString(
-        for: kUsersNotFoundError
-      )
-    case .userDisabled:
-      return localizedString(
-        for: kAccountDisabledError
-      )
-    default:
-      return error.localizedDescription
+      let authError = error as NSError
+      let errorCode = AuthErrorCode(rawValue: authError.code)
+      switch errorCode {
+      case .emailAlreadyInUse:
+        return localizedString(
+          for: "EmailAlreadyInUseError"
+        )
+      case .invalidEmail:
+        return localizedString(for: "InvalidEmailError")
+      case .weakPassword:
+        return localizedString(for: "WeakPasswordError")
+      case .tooManyRequests:
+        return localizedString(
+          for: "SignUpTooManyTimesError"
+        )
+      case .wrongPassword:
+        return localizedString(
+          for: "WrongPasswordError"
+        )
+      case .userNotFound:
+        return localizedString(
+          for: "UserNotFoundError"
+        )
+      case .userDisabled:
+        return localizedString(
+          for: "AccountDisabledError"
+        )
+      default:
+        return error.localizedDescription
+      }
     }
-  }
 
   /// Auth Picker title
   /// found in:

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/AuthPickerView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/AuthPickerView.swift
@@ -18,6 +18,10 @@ public struct AuthPickerView<Content: View> {
 extension AuthPickerView: View {
   public var body: some View {
     VStack {
+      Text(authService.string.localizedString(for: kAuthPickerTitle))
+        .font(.largeTitle)
+        .fontWeight(.bold)
+        .padding()
       if authService.authenticationState == .authenticated {
         SignedInView()
       } else if authService.authView == .passwordRecovery {

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/AuthPickerView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/AuthPickerView.swift
@@ -29,21 +29,23 @@ extension AuthPickerView: View {
       } else if authService.authView == .emailLink {
         EmailLinkView()
       } else {
-        Text(authService.authenticationFlow == .login ? "Login" : "Sign up")
+        Text(authService.authenticationFlow == .login ? authService.string
+          .emailLoginFlowLabel : authService.string.emailSignUpFlowLabel)
         VStack { Divider() }
         EmailAuthView()
         authService.renderButtons()
         VStack { Divider() }
         HStack {
           Text(authService
-            .authenticationFlow == .login ? "Don't have an account yet?" :
-            "Already have an account?")
+            .authenticationFlow == .login ? authService.string.dontHaveAnAccountYetLabel :
+            authService.string.alreadyHaveAnAccountLabel)
           Button(action: {
             withAnimation {
               switchFlow()
             }
           }) {
-            Text(authService.authenticationFlow == .signUp ? "Log in" : "Sign up")
+            Text(authService.authenticationFlow == .signUp ? authService.string
+              .emailLoginFlowLabel : authService.string.emailSignUpFlowLabel)
               .fontWeight(.semibold)
               .foregroundColor(.blue)
           }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/AuthPickerView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/AuthPickerView.swift
@@ -18,7 +18,7 @@ public struct AuthPickerView<Content: View> {
 extension AuthPickerView: View {
   public var body: some View {
     VStack {
-      Text(authService.string.localizedString(for: kAuthPickerTitle))
+      Text(authService.string.authPickerTitle)
         .font(.largeTitle)
         .fontWeight(.bold)
         .padding()

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/EmailAuthView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/EmailAuthView.swift
@@ -50,7 +50,7 @@ extension EmailAuthView: View {
   public var body: some View {
     VStack {
       LabeledContent {
-        TextField(authService.string.localizedString(for: kEnterYourEmail), text: $email)
+        TextField(authService.string.emailInputLabel, text: $email)
           .textInputAutocapitalization(.never)
           .disableAutocorrection(true)
           .focused($focus, equals: .email)
@@ -66,7 +66,7 @@ extension EmailAuthView: View {
       .padding(.bottom, 4)
 
       LabeledContent {
-        SecureField(authService.string.localizedString(for: kEnterYourPassword), text: $password)
+        SecureField(authService.string.passwordInputLabel, text: $password)
           .focused($focus, equals: .password)
           .submitLabel(.go)
           .onSubmit {
@@ -83,7 +83,7 @@ extension EmailAuthView: View {
         Button(action: {
           authService.authView = .passwordRecovery
         }) {
-          Text(authService.string.localizedString(for: kForgotPasswordButtonLabel))
+          Text(authService.string.passwordButtonLabel)
         }
       }
 

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/EmailAuthView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/EmailAuthView.swift
@@ -50,7 +50,7 @@ extension EmailAuthView: View {
   public var body: some View {
     VStack {
       LabeledContent {
-        TextField("Email", text: $email)
+        TextField(authService.string.localizedString(for: kEnterYourEmail), text: $email)
           .textInputAutocapitalization(.never)
           .disableAutocorrection(true)
           .focused($focus, equals: .email)
@@ -66,7 +66,7 @@ extension EmailAuthView: View {
       .padding(.bottom, 4)
 
       LabeledContent {
-        SecureField("Password", text: $password)
+        SecureField(authService.string.localizedString(for: kEnterYourPassword), text: $password)
           .focused($focus, equals: .password)
           .submitLabel(.go)
           .onSubmit {

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/EmailAuthView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/EmailAuthView.swift
@@ -89,7 +89,7 @@ extension EmailAuthView: View {
 
       if authService.authenticationFlow == .signUp {
         LabeledContent {
-          SecureField("Confirm password", text: $confirmPassword)
+          SecureField(authService.string.confirmPasswordInputLabel, text: $confirmPassword)
             .focused($focus, equals: .confirmPassword)
             .submitLabel(.go)
             .onSubmit {
@@ -110,7 +110,8 @@ extension EmailAuthView: View {
         }
       }) {
         if authService.authenticationState != .authenticating {
-          Text(authService.authenticationFlow == .login ? "Log in with password" : "Sign up")
+          Text(authService.authenticationFlow == .login ? authService.string
+            .signInWithEmailButtonLabel : authService.string.signUpWithEmailButtonLabel)
             .padding(.vertical, 8)
             .frame(maxWidth: .infinity)
         } else {
@@ -127,7 +128,7 @@ extension EmailAuthView: View {
       Button(action: {
         authService.authView = .passwordRecovery
       }) {
-        Text("Prefer Email link sign-in?")
+        Text(authService.string.signUpWithEmailLinkButtonLabel)
       }
     }
   }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/EmailAuthView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/EmailAuthView.swift
@@ -83,7 +83,7 @@ extension EmailAuthView: View {
         Button(action: {
           authService.authView = .passwordRecovery
         }) {
-          Text("Forgotten Password?")
+          Text(authService.string.localizedString(for: kForgotPasswordButtonLabel))
         }
       }
 

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/EmailLinkView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/EmailLinkView.swift
@@ -19,9 +19,9 @@ public struct EmailLinkView {
 extension EmailLinkView: View {
   public var body: some View {
     VStack {
-      Text("Sign in with email link")
+      Text(authService.string.signInWithEmailLinkViewTitle)
       LabeledContent {
-        TextField("Email", text: $email)
+        TextField(authService.string.emailInputLabel, text: $email)
           .textInputAutocapitalization(.never)
           .disableAutocorrection(true)
           .submitLabel(.next)
@@ -36,7 +36,7 @@ extension EmailLinkView: View {
           authService.emailLink = email
         }
       }) {
-        Text("Send email sign-in link")
+        Text(authService.string.sendEmailLinkButtonLabel)
           .padding(.vertical, 8)
           .frame(maxWidth: .infinity)
       }
@@ -47,11 +47,9 @@ extension EmailLinkView: View {
       Text(authService.errorMessage).foregroundColor(.red)
     }.sheet(isPresented: $showModal) {
       VStack {
-        Text("Instructions")
-          .font(.headline)
-        Text("Please check your email for email sign-in link.")
+        Text(authService.string.signInWithEmailLinkViewMessage)
           .padding()
-        Button("Dismiss") {
+        Button(authService.string.okButtonLabel) {
           showModal = false
         }
         .padding()
@@ -69,7 +67,7 @@ extension EmailLinkView: View {
     }) {
       Image(systemName: "chevron.left")
         .foregroundColor(.blue)
-      Text("Back")
+      Text(authService.string.backButtonLabel)
         .foregroundColor(.blue)
     })
   }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/PasswordPromptView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/PasswordPromptView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct PasswordPromptSheet {
+  @Environment(AuthService.self) private var authService
   @Bindable var coordinator: PasswordPromptCoordinator
   @State private var password = ""
 }
@@ -8,16 +9,16 @@ struct PasswordPromptSheet {
 extension PasswordPromptSheet: View {
   var body: some View {
     VStack(spacing: 20) {
-      SecureField("Enter Password", text: $password)
+      SecureField(authService.string.passwordInputLabel, text: $password)
         .textFieldStyle(.roundedBorder)
         .padding()
 
       HStack {
-        Button("Cancel") {
+        Button(authService.string.cancelButtonLabel) {
           coordinator.cancel()
         }
         Spacer()
-        Button("Submit") {
+        Button(authService.string.okButtonLabel) {
           coordinator.submit(password: password)
         }
         .disabled(password.isEmpty)

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/PasswordRecoveryView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/PasswordRecoveryView.swift
@@ -18,7 +18,7 @@ public struct PasswordRecoveryView {
 extension PasswordRecoveryView: View {
   public var body: some View {
     VStack {
-      Text(authService.string.localizedString(for: kPasswordRecoveryTitle))
+      Text(authService.string.passwordRecoveryTitle)
         .font(.largeTitle)
         .fontWeight(.bold)
         .padding()
@@ -26,7 +26,7 @@ extension PasswordRecoveryView: View {
       Divider()
 
       LabeledContent {
-        TextField(authService.string.localizedString(for: kEnterYourEmail), text: $email)
+        TextField(authService.string.emailInputLabel, text: $email)
           .textInputAutocapitalization(.never)
           .disableAutocorrection(true)
           .submitLabel(.next)
@@ -40,7 +40,7 @@ extension PasswordRecoveryView: View {
           await sendPasswordRecoveryEmail()
         }
       }) {
-        Text(authService.string.localizedString(for: kForgotPasswordInputLabel))
+        Text(authService.string.forgotPasswordInputLabel)
           .padding(.vertical, 8)
           .frame(maxWidth: .infinity)
       }
@@ -50,18 +50,18 @@ extension PasswordRecoveryView: View {
       .buttonStyle(.borderedProminent)
     }.sheet(isPresented: $showModal) {
       VStack {
-        Text(authService.string.localizedString(for: kPasswordRecoveryEmailSentTitle))
+        Text(authService.string.passwordRecoveryEmailSentTitle)
           .font(.largeTitle)
           .fontWeight(.bold)
           .padding()
-        Text(authService.string.localizedString(for: kPasswordRecoveryMessage))
+        Text(authService.string.passwordRecoveryMessage)
           .padding()
 
         Divider()
 
-        Text(authService.string.localizedString(for: kPasswordRecoveryEmailSentMessage))
+        Text(authService.string.passwordRecoveryEmailSentMessage)
           .padding()
-        Button(authService.string.localizedString(for: kOK)) {
+        Button(authService.string.okButtonLabel) {
           showModal = false
         }
         .padding()
@@ -75,7 +75,7 @@ extension PasswordRecoveryView: View {
     }) {
       Image(systemName: "chevron.left")
         .foregroundColor(.blue)
-      Text(authService.string.localizedString(for: kBack))
+      Text(authService.string.backButtonLabel)
         .foregroundColor(.blue)
     })
   }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/PasswordRecoveryView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/PasswordRecoveryView.swift
@@ -18,9 +18,15 @@ public struct PasswordRecoveryView {
 extension PasswordRecoveryView: View {
   public var body: some View {
     VStack {
-      Text("Password Recovery")
+      Text(authService.string.localizedString(for: kPasswordRecoveryTitle))
+        .font(.largeTitle)
+        .fontWeight(.bold)
+        .padding()
+
+      Divider()
+
       LabeledContent {
-        TextField("Email", text: $email)
+        TextField(authService.string.localizedString(for: kEnterYourEmail), text: $email)
           .textInputAutocapitalization(.never)
           .disableAutocorrection(true)
           .submitLabel(.next)
@@ -34,7 +40,7 @@ extension PasswordRecoveryView: View {
           await sendPasswordRecoveryEmail()
         }
       }) {
-        Text("Password Recovery")
+        Text(authService.string.localizedString(for: kForgotPasswordInputLabel))
           .padding(.vertical, 8)
           .frame(maxWidth: .infinity)
       }
@@ -44,11 +50,18 @@ extension PasswordRecoveryView: View {
       .buttonStyle(.borderedProminent)
     }.sheet(isPresented: $showModal) {
       VStack {
-        Text("Instructions")
-          .font(.headline)
-        Text("Please check your email for password recovery instructions.")
+        Text(authService.string.localizedString(for: kPasswordRecoveryEmailSentTitle))
+          .font(.largeTitle)
+          .fontWeight(.bold)
           .padding()
-        Button("Dismiss") {
+        Text(authService.string.localizedString(for: kPasswordRecoveryMessage))
+          .padding()
+
+        Divider()
+
+        Text(authService.string.localizedString(for: kPasswordRecoveryEmailSentMessage))
+          .padding()
+        Button(authService.string.localizedString(for: kOK)) {
           showModal = false
         }
         .padding()
@@ -62,7 +75,7 @@ extension PasswordRecoveryView: View {
     }) {
       Image(systemName: "chevron.left")
         .foregroundColor(.blue)
-      Text("Back")
+      Text(authService.string.localizedString(for: kBack))
         .foregroundColor(.blue)
     })
   }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/PasswordRecoveryView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/PasswordRecoveryView.swift
@@ -54,7 +54,7 @@ extension PasswordRecoveryView: View {
           .font(.largeTitle)
           .fontWeight(.bold)
           .padding()
-        Text(authService.string.passwordRecoveryMessage)
+        Text(authService.string.passwordRecoveryHelperMessage)
           .padding()
 
         Divider()

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/SignedInView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/SignedInView.swift
@@ -15,7 +15,7 @@ extension SignedInView: View {
 
   public var body: some View {
     VStack {
-      Text(authService.string.localizedString(for: kSignedInTitle))
+      Text(authService.string.signedInTitle)
         .font(.largeTitle)
         .fontWeight(.bold)
         .padding()

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/SignedInView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/SignedInView.swift
@@ -15,7 +15,10 @@ extension SignedInView: View {
 
   public var body: some View {
     VStack {
-      Text("Signed in")
+      Text(authService.string.localizedString(for: kSignedInTitle))
+        .font(.largeTitle)
+        .fontWeight(.bold)
+        .padding()
       Text("User: \(authService.currentUser?.email ?? "Unknown")")
 
       if authService.currentUser?.isEmailVerified == false {

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/SignedInView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/SignedInView.swift
@@ -20,11 +20,11 @@ extension SignedInView: View {
     } else {
       VStack {
         Text(authService.string.signedInTitle)
-        .font(.largeTitle)
-        .fontWeight(.bold)
-        .padding()
-      Text(authService.string.accountSettingsEmailLabel)
-      Text("\(authService.currentUser?.email ?? "Unknown")")
+          .font(.largeTitle)
+          .fontWeight(.bold)
+          .padding()
+        Text(authService.string.accountSettingsEmailLabel)
+        Text("\(authService.currentUser?.email ?? "Unknown")")
 
         if authService.currentUser?.isEmailVerified == false {
           VerifyEmailView()

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/SignedInView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/SignedInView.swift
@@ -19,13 +19,14 @@ extension SignedInView: View {
         .font(.largeTitle)
         .fontWeight(.bold)
         .padding()
-      Text("User: \(authService.currentUser?.email ?? "Unknown")")
+      Text(authService.string.accountSettingsEmailLabel)
+      Text("\(authService.currentUser?.email ?? "Unknown")")
 
       if authService.currentUser?.isEmailVerified == false {
         VerifyEmailView()
       }
 
-      Button("Sign out") {
+      Button(authService.string.signOutButtonLabel) {
         Task {
           do {
             try await authService.signOut()
@@ -33,7 +34,7 @@ extension SignedInView: View {
         }
       }
       Divider()
-      Button("Delete account") {
+      Button(authService.string.deleteAccountButtonLabel) {
         Task {
           do {
             try await authService.deleteUser()

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/SignedInView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/SignedInView.swift
@@ -30,7 +30,7 @@ extension SignedInView: View {
           VerifyEmailView()
         }
         Divider()
-        Button("Update password") {
+        Button(authService.string.updatePasswordButtonLabel) {
           authService.authView = .updatePassword
         }
         Divider()

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/UpdatePassword.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/UpdatePassword.swift
@@ -35,7 +35,7 @@ extension UpdatePasswordView: View {
   public var body: some View {
     VStack {
       LabeledContent {
-        SecureField("Password", text: $password)
+        SecureField(authService.string.passwordInputLabel, text: $password)
           .focused($focus, equals: .password)
           .submitLabel(.go)
       } label: {
@@ -48,7 +48,7 @@ extension UpdatePasswordView: View {
       Divider()
 
       LabeledContent {
-        SecureField("Confirm password", text: $confirmPassword)
+        SecureField(authService.string.confirmPasswordInputLabel, text: $confirmPassword)
           .focused($focus, equals: .confirmPassword)
           .submitLabel(.go)
       } label: {
@@ -66,7 +66,7 @@ extension UpdatePasswordView: View {
           authService.authView = .authPicker
         }
       }, label: {
-        Text("Update password")
+        Text(authService.string.updatePasswordButtonLabel)
           .padding(.vertical, 8)
           .frame(maxWidth: .infinity)
 

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/VerifyEmailView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/VerifyEmailView.swift
@@ -21,7 +21,7 @@ extension VerifyEmailView: View {
           await sendEmailVerification()
         }
       }) {
-        Text("Verify email address?")
+        Text(authService.string.sendEmailVerificationButtonLabel)
           .padding(.vertical, 8)
           .frame(maxWidth: .infinity)
       }
@@ -30,11 +30,9 @@ extension VerifyEmailView: View {
       .buttonStyle(.borderedProminent)
     }.sheet(isPresented: $showModal) {
       VStack {
-        Text("Instructions")
+        Text(authService.string.verifyEmailSheetMessage)
           .font(.headline)
-        Text("Please check your email for verification link.")
-          .padding()
-        Button("Dismiss") {
+        Button(authService.string.okButtonLabel) {
           showModal = false
         }
         .padding()

--- a/FirebaseSwiftUI/FirebaseFacebookSwiftUI/Sources/Views/SignInWithFacebookButton.swift
+++ b/FirebaseSwiftUI/FirebaseFacebookSwiftUI/Sources/Views/SignInWithFacebookButton.swift
@@ -66,7 +66,7 @@ extension SignInWithFacebookButton: View {
         Image(systemName: "f.circle.fill")
           .font(.title)
           .foregroundColor(.white)
-        Text("Continue with Facebook")
+        Text(authService.string.facebookLoginButtonLabel)
           .fontWeight(.semibold)
           .foregroundColor(.white)
       }
@@ -77,13 +77,13 @@ extension SignInWithFacebookButton: View {
     }
     .alert(isPresented: $showCanceledAlert) {
       Alert(
-        title: Text("Facebook login cancelled"),
-        dismissButton: .default(Text("OK"))
+        title: Text(authService.string.facebookLoginCancelledLabel),
+        dismissButton: .default(Text(authService.string.okButtonLabel))
       )
     }
 
     HStack {
-      Text("Authorize User Tracking")
+      Text(authService.string.authorizeUserTrackingLabel)
         .font(.footnote)
         .foregroundColor(.blue)
         .underline()
@@ -93,16 +93,16 @@ extension SignInWithFacebookButton: View {
       Toggle(isOn: limitedLoginBinding) {
         HStack {
           Spacer() // This will push the text to the left of the toggle
-          Text("Limited Login")
+          Text(authService.string.facebookLimitedLoginLabel)
             .foregroundColor(.blue)
         }
       }
       .toggleStyle(SwitchToggleStyle(tint: .green))
       .alert(isPresented: $showUserTrackingAlert) {
         Alert(
-          title: Text("Authorize User Tracking"),
-          message: Text("For classic Facebook login, please authorize user tracking."),
-          dismissButton: .default(Text("OK"))
+          title: Text(authService.string.authorizeUserTrackingLabel),
+          message: Text(authService.string.facebookAuthorizeUserTrackingMessage),
+          dismissButton: .default(Text(authService.string.okButtonLabel))
         )
       }
     }

--- a/FirebaseSwiftUI/FirebasePhoneAuthSwiftUI/Sources/Views/PhoneAuthButtonView.swift
+++ b/FirebaseSwiftUI/FirebasePhoneAuthSwiftUI/Sources/Views/PhoneAuthButtonView.swift
@@ -19,7 +19,7 @@ extension PhoneAuthButtonView: View {
     if authService.authenticationState != .authenticating {
       VStack {
         LabeledContent {
-          TextField("Enter phone number", text: $phoneNumber)
+          TextField(authService.string.enterPhoneNumberLabel, text: $phoneNumber)
             .textInputAutocapitalization(.never)
             .disableAutocorrection(true)
             .submitLabel(.next)
@@ -41,7 +41,7 @@ extension PhoneAuthButtonView: View {
             }
           }
         }) {
-          Text("Send SMS code")
+          Text(authService.string.smsCodeSentLabel)
             .padding(.vertical, 8)
             .frame(maxWidth: .infinity)
         }
@@ -51,7 +51,7 @@ extension PhoneAuthButtonView: View {
         .buttonStyle(.borderedProminent)
         Text(errorMessage).foregroundColor(.red)
       }.sheet(isPresented: $showVerificationCodeInput) {
-        TextField("Enter verification code", text: $verificationCode)
+        TextField(authService.string.phoneNumberVerificationCodeLabel, text: $verificationCode)
           .keyboardType(.numberPad)
           .padding()
           .background(Color(.systemGray6))
@@ -71,7 +71,7 @@ extension PhoneAuthButtonView: View {
             showVerificationCodeInput = false
           }
         }) {
-          Text("Verify phone number and sign-in")
+          Text(authService.string.verifyPhoneNumberAndSignInLabel)
             .foregroundColor(.white)
             .padding()
             .frame(maxWidth: .infinity)


### PR DESCRIPTION
PR contains string localization implementation.

A couple of things to note;

- There are no strings as far as I can see for verifying email so I left VerifyEmailView as it is, until the below question is resolved.
- I haven't touched the Facebook, Phone or Google provider Swift package until the question below has been resolved.

**Questions**
1. Should we keep all strings within the core package?  If they need to be within their own Swift package (e.g. Facebook strings in Facebook Swift package), then this would require some refactoring to the internal implementation so we can make use of each packages `Bundle.module` which contains the strings.
2. Should we add strings to the string catalog for missing strings such as verifying email?


