### PR TITLE
Few more updates before alpha release

### DIFF
--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/AuthServiceError.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/AuthServiceError.swift
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 import FirebaseAuth
 import SwiftUI
 

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/UpdatePassword.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/UpdatePassword.swift
@@ -19,6 +19,7 @@
 //  Created by Russell Wheatley on 24/04/2025.
 //
 
+import FirebaseCore
 import SwiftUI
 
 private enum FocusableField: Hashable {
@@ -93,4 +94,11 @@ extension UpdatePasswordView: View {
       PasswordPromptSheet(coordinator: authService.passwordPrompt)
     }
   }
+}
+
+
+#Preview {
+  FirebaseOptions.dummyConfigurationForPreview()
+  return UpdatePasswordView()
+    .environment(AuthService())
 }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/UpdatePassword.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/UpdatePassword.swift
@@ -96,7 +96,6 @@ extension UpdatePasswordView: View {
   }
 }
 
-
 #Preview {
   FirebaseOptions.dummyConfigurationForPreview()
   return UpdatePasswordView()

--- a/FirebaseSwiftUI/FirebaseFacebookSwiftUI/Sources/Views/SignInWithFacebookButton.swift
+++ b/FirebaseSwiftUI/FirebaseFacebookSwiftUI/Sources/Views/SignInWithFacebookButton.swift
@@ -42,7 +42,7 @@ public struct SignInWithFacebookButton {
         if trackingAuthorizationStatus == .authorized {
           self.limitedLogin = newValue
         } else {
-          self.limitedLogin = false
+          self.limitedLogin = true
         }
       }
     )

--- a/FirebaseSwiftUI/FirebaseFacebookSwiftUI/Sources/Views/SignInWithFacebookButton.swift
+++ b/FirebaseSwiftUI/FirebaseFacebookSwiftUI/Sources/Views/SignInWithFacebookButton.swift
@@ -121,7 +121,6 @@ extension SignInWithFacebookButton: View {
         )
       }
     }
-    Text(errorMessage).foregroundColor(.red)
   }
 }
 


### PR DESCRIPTION
A few updates that are in commits relevant to the fix/update:

1. Added preview to update password view: https://github.com/firebase/FirebaseUI-iOS/commit/3ab5c89d9e22e13e0ef13b742b00300cbb80d832
2. Removed error message duplication if issue signing-in with Facebook: https://github.com/firebase/FirebaseUI-iOS/commit/90875c035a6b3a47f842d10d875f4ac5f9bdbe6f
3. Bug fix - limited login should be locked if tracking is not allowed: https://github.com/firebase/FirebaseUI-iOS/commit/a0dee1a63fa0bea255181a18f15560c3963d260c
4. Pass in action code settings if available for email verification: https://github.com/firebase/FirebaseUI-iOS/commit/2c470a4ee84b396f0e531582de12986f26dee570

I think post alpha release, we should probably think about some form of global sheet alert for error updates.