### PR TITLE
refactor: remove AuthenticationToken as it is not needed

### DIFF
--- a/FirebaseSwiftUI/FirebaseAppleSwiftUI/Sources/Services/AccountService+Apple.swift
+++ b/FirebaseSwiftUI/FirebaseAppleSwiftUI/Sources/Services/AccountService+Apple.swift
@@ -14,7 +14,7 @@ protocol AppleOperationReauthentication {
 }
 
 extension AppleOperationReauthentication {
-  @MainActor func reauthenticate() async throws -> AuthenticationToken {
+  @MainActor func reauthenticate() async throws {
     guard let user = Auth.auth().currentUser else {
       throw AuthServiceError.reauthenticationRequired("No user currently signed-in")
     }
@@ -22,8 +22,6 @@ extension AppleOperationReauthentication {
     do {
       let credential = try await appleProvider.createAuthCredential()
       try await user.reauthenticate(with: credential)
-
-      return .firebase("")
     } catch {
       throw AuthServiceError.signInFailed(underlying: error)
     }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Services/AccountService+Email.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Services/AccountService+Email.swift
@@ -21,7 +21,7 @@ protocol EmailPasswordOperationReauthentication {
 
 extension EmailPasswordOperationReauthentication {
   // TODO: - @MainActor because User is non-sendable. Might change this once User is sendable in firebase-ios-sdk
-  @MainActor func reauthenticate() async throws -> AuthenticationToken {
+  @MainActor func reauthenticate() async throws {
     guard let user = Auth.auth().currentUser else {
       throw AuthServiceError.reauthenticationRequired("No user currently signed-in")
     }
@@ -35,8 +35,6 @@ extension EmailPasswordOperationReauthentication {
 
       let credential = EmailAuthProvider.credential(withEmail: email, password: password)
       try await Auth.auth().currentUser?.reauthenticate(with: credential)
-
-      return .firebase("")
     } catch {
       throw AuthServiceError.signInFailed(underlying: error)
     }

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Services/AccountService.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Services/AccountService.swift
@@ -25,15 +25,10 @@ extension NSError {
   }
 }
 
-public enum AuthenticationToken {
-  case apple(ASAuthorizationAppleIDCredential, String)
-  case firebase(String)
-}
-
 @MainActor
 public protocol AuthenticatedOperation {
   func callAsFunction(on user: User) async throws
-  func reauthenticate() async throws -> AuthenticationToken
+  func reauthenticate() async throws
 }
 
 public extension AuthenticatedOperation {

--- a/FirebaseSwiftUI/FirebaseFacebookSwiftUI/Sources/Services/AccountService+Facebook.swift
+++ b/FirebaseSwiftUI/FirebaseFacebookSwiftUI/Sources/Services/AccountService+Facebook.swift
@@ -28,7 +28,7 @@ protocol FacebookOperationReauthentication {
 }
 
 extension FacebookOperationReauthentication {
-  @MainActor func reauthenticate() async throws -> AuthenticationToken {
+  @MainActor func reauthenticate() async throws {
     guard let user = Auth.auth().currentUser else {
       throw AuthServiceError.reauthenticationRequired("No user currently signed-in")
     }
@@ -36,8 +36,6 @@ extension FacebookOperationReauthentication {
     do {
       let credential = try await facebookProvider.createAuthCredential()
       try await user.reauthenticate(with: credential)
-
-      return .firebase("")
     } catch {
       throw AuthServiceError.signInFailed(underlying: error)
     }

--- a/FirebaseSwiftUI/FirebaseGoogleSwiftUI/Sources/Services/AccountService+Google.swift
+++ b/FirebaseSwiftUI/FirebaseGoogleSwiftUI/Sources/Services/AccountService+Google.swift
@@ -35,7 +35,7 @@ protocol GoogleOperationReauthentication {
 }
 
 extension GoogleOperationReauthentication {
-  @MainActor func reauthenticate() async throws -> AuthenticationToken {
+  @MainActor func reauthenticate() async throws {
     guard let user = Auth.auth().currentUser else {
       throw AuthServiceError.reauthenticationRequired("No user currently signed-in")
     }
@@ -44,7 +44,6 @@ extension GoogleOperationReauthentication {
       let credential = try await googleProvider.createAuthCredential()
       try await user.reauthenticate(with: credential)
 
-      return .firebase("")
     } catch {
       throw AuthServiceError.signInFailed(underlying: error)
     }

--- a/FirebaseSwiftUI/FirebaseOAuthSwiftUI/Sources/Services/AccountService+OAuth.swift
+++ b/FirebaseSwiftUI/FirebaseOAuthSwiftUI/Sources/Services/AccountService+OAuth.swift
@@ -14,7 +14,7 @@ protocol OAuthOperationReauthentication {
 }
 
 extension OAuthOperationReauthentication {
-  @MainActor func reauthenticate() async throws -> AuthenticationToken {
+  @MainActor func reauthenticate() async throws {
     guard let user = Auth.auth().currentUser else {
       throw AuthServiceError.reauthenticationRequired("No user currently signed-in")
     }
@@ -22,8 +22,6 @@ extension OAuthOperationReauthentication {
     do {
       let credential = try await oauthProvider.createAuthCredential()
       try await user.reauthenticate(with: credential)
-
-      return .firebase("")
     } catch {
       throw AuthServiceError.signInFailed(underlying: error)
     }

--- a/FirebaseSwiftUI/FirebaseTwitterSwiftUI/Sources/Services/AccountService+Twitter.swift
+++ b/FirebaseSwiftUI/FirebaseTwitterSwiftUI/Sources/Services/AccountService+Twitter.swift
@@ -14,7 +14,7 @@ protocol TwitterOperationReauthentication {
 }
 
 extension TwitterOperationReauthentication {
-  @MainActor func reauthenticate() async throws -> AuthenticationToken {
+  @MainActor func reauthenticate() async throws {
     guard let user = Auth.auth().currentUser else {
       throw AuthServiceError.reauthenticationRequired("No user currently signed-in")
     }
@@ -22,8 +22,6 @@ extension TwitterOperationReauthentication {
     do {
       let credential = try await twitterProvider.createAuthCredential()
       try await user.reauthenticate(with: credential)
-
-      return .firebase("")
     } catch {
       throw AuthServiceError.signInFailed(underlying: error)
     }


### PR DESCRIPTION
- Removes `AuthenticationToken` from `reauthenticate()`  method as it is no longer used or needed.
