### PR TITLE
feat: bump facebook SDK to >= v18

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -66,7 +66,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/facebook/facebook-ios-sdk.git",
-      "17.0.0" ..< "18.0.0"
+      "18.0.0" ..< "19.0.0"
     ),
     .package(
       url: "https://github.com/firebase/firebase-ios-sdk.git",


### PR DESCRIPTION
closes https://github.com/firebase/FirebaseUI-iOS/issues/1269

- bumped facebook SDK to min v18
