### PR TITLE
ci: introduce workflow for tracking issues/prs for Invertase internal project board

### DIFF
--- a/.github/workflows/project-manager.yml
+++ b/.github/workflows/project-manager.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   id-token: write
-  contents: read
   issues: read
   pull-requests: read
 
@@ -18,7 +17,6 @@ jobs:
   forward:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
       - uses: invertase/invertase-project-board@v1
         with:
           project-boards: '[73]'


### PR DESCRIPTION
- Just sends publicly available data for issues/prs to Invertase endpoint which allows us to sync our internal project board for FirebaseUI.
- [id-token](https://github.com/firebase/FirebaseUI-iOS/pull/1323/changes#diff-d3b133a29609fedad730db30205dc89636a7c6b5d0159915e35bfca1e1b475fcR12) is used to confirm identity of repo sending issue/pr payload.