### PR TITLE
fix(auth): do not show MFA button when the project does not have MFA enabled

### DIFF
--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/SignedInView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/SignedInView.swift
@@ -23,6 +23,14 @@ public struct SignedInView {
   @State private var showEmailVerificationSent = false
   @State private var reauthCoordinator = ReauthenticationCoordinator()
 
+  var showsMfaManagementButton: Bool {
+    Self.showsMfaManagementButton(configuration: authService.configuration)
+  }
+
+  static func showsMfaManagementButton(configuration: AuthConfiguration) -> Bool {
+    configuration.mfaEnabled
+  }
+
   private func sendEmailVerification() async throws {
     do {
       try await authService.sendEmailVerification()
@@ -75,17 +83,19 @@ extension SignedInView: View {
       .frame(maxWidth: .infinity)
       .accessibilityIdentifier("update-password-button")
 
-      Button {
-        authService.navigator.push(.mfaManagement)
-      } label: {
-        Text(authService.string.manageTwoFactorAuthenticationLabel)
-          .padding(.vertical, 8)
-          .frame(maxWidth: .infinity)
+      if showsMfaManagementButton {
+        Button {
+          authService.navigator.push(.mfaManagement)
+        } label: {
+          Text(authService.string.manageTwoFactorAuthenticationLabel)
+            .padding(.vertical, 8)
+            .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.borderedProminent)
+        .padding([.top, .bottom], 8)
+        .frame(maxWidth: .infinity)
+        .accessibilityIdentifier("mfa-management-button")
       }
-      .buttonStyle(.borderedProminent)
-      .padding([.top, .bottom], 8)
-      .frame(maxWidth: .infinity)
-      .accessibilityIdentifier("mfa-management-button")
 
       Button {
         showDeleteConfirmation = true

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/SignedInView.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Sources/Views/SignedInView.swift
@@ -23,7 +23,7 @@ public struct SignedInView {
   @State private var showEmailVerificationSent = false
   @State private var reauthCoordinator = ReauthenticationCoordinator()
 
-  var showsMfaManagementButton: Bool {
+  private var showsMfaManagementButton: Bool {
     Self.showsMfaManagementButton(configuration: authService.configuration)
   }
 

--- a/FirebaseSwiftUI/FirebaseAuthSwiftUI/Tests/FirebaseAuthSwiftUITests/SignedInViewTests.swift
+++ b/FirebaseSwiftUI/FirebaseAuthSwiftUI/Tests/FirebaseAuthSwiftUITests/SignedInViewTests.swift
@@ -1,0 +1,33 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@testable import FirebaseAuthSwiftUI
+import Testing
+
+@Suite("SignedInView Tests")
+struct SignedInViewTests {
+  @Test("MFA management button is hidden when MFA is disabled")
+  func mfaManagementButtonHiddenWhenMfaDisabled() {
+    let configuration = AuthConfiguration(mfaEnabled: false)
+
+    #expect(SignedInView.showsMfaManagementButton(configuration: configuration) == false)
+  }
+
+  @Test("MFA management button is shown when MFA is enabled")
+  func mfaManagementButtonShownWhenMfaEnabled() {
+    let configuration = AuthConfiguration(mfaEnabled: true)
+
+    #expect(SignedInView.showsMfaManagementButton(configuration: configuration) == true)
+  }
+}


### PR DESCRIPTION
This is a simple change to the SignedIn view to conditionally disable showing the manage MFA button when this feature is not enabled in the Firebase project, to prevent user confusion.

Also added a corresponding UI test for this behavior.
