### PR TITLE
Add stale issue and PR workflow

### DIFF
--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -1,0 +1,42 @@
+---
+name: Mark stale issues and pull requests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '35 * * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    permissions:
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          operations-per-run: 1000
+          stale-issue-message: |
+            Hello, to help manage issues we automatically close stale issues.
+
+            This issue has been automatically marked as stale because it has not had activity for quite some time. Has this issue been fixed, or does it still require attention?
+
+            > This issue will be closed in 15 days if no further activity occurs.
+
+            Thank you for your contributions.
+          stale-pr-message: |
+            Hello, this PR has been open for more than 2 months with no activity.
+
+            If you think this is a mistake, please comment and ping a maintainer to get this merged ASAP. Thanks for contributing!
+
+            You have 15 days until this gets closed automatically.
+          exempt-issue-labels: 'keep open'
+          exempt-pr-labels: 'keep open'
+          close-issue-reason: not-planned
+          days-before-stale: 28
+          days-before-close: 15
+          stale-issue-label: 'not-planned'
+          stale-pr-label: 'Stale'

--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -4,7 +4,7 @@ name: Mark stale issues and pull requests
 on:
   workflow_dispatch:
   schedule:
-    - cron: '35 * * * *'
+    - cron: '30 1 * * *'
 
 permissions:
   contents: read
@@ -22,17 +22,17 @@ jobs:
           stale-issue-message: |
             Hello, to help manage issues we automatically close stale issues.
 
-            This issue has been automatically marked as stale because it has not had activity for quite some time. Has this issue been fixed, or does it still require attention?
+            This issue has been automatically marked as stale because it has not had activity for quite some time. If it is still relevant, leave a comment to keep it open.
 
             > This issue will be closed in 15 days if no further activity occurs.
 
             Thank you for your contributions.
           stale-pr-message: |
-            Hello, this PR has been open for more than 2 months with no activity.
+            Hello, this PR has been open for more than 28 days with no activity.
 
-            If you think this is a mistake, please comment and ping a maintainer to get this merged ASAP. Thanks for contributing!
+            If you think this is a mistake, please comment to keep this open. Thanks for contributing!
 
-            You have 15 days until this gets closed automatically.
+            > This PR will be closed in 15 days if no further activity occurs.
           exempt-issue-labels: 'keep open'
           exempt-pr-labels: 'keep open'
           close-issue-reason: not-planned

--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           operations-per-run: 1000
           stale-issue-message: |


### PR DESCRIPTION
Adds a GitHub Actions workflow using `actions/stale` to automatically mark inactive issues and PRs as stale, then close them after 15 additional days without activity.
