### PR TITLE
fix(FirebaseStorageUI): fix SPM build failure with Firebase Storage 11.x

### DIFF
--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@main
       - name: Select Xcode version
         run: |
-          sudo xcode-select -switch /Applications/Xcode_16.3.app/Contents/Developer
+          sudo xcode-select -switch /Applications/Xcode_16.4.app/Contents/Developer
       - name: List
         run: |
           xcodebuild -list
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@main
       - name: Select Xcode version
         run: |
-          sudo xcode-select -switch /Applications/Xcode_16.3.app/Contents/Developer
+          sudo xcode-select -switch /Applications/Xcode_16.4.app/Contents/Developer
       - name: Setup
         run: gem install bundler; bundle install
       - name: Build

--- a/FirebaseStorageUI/Sources/FIRStorageDownloadTask+SDWebImage.m
+++ b/FirebaseStorageUI/Sources/FIRStorageDownloadTask+SDWebImage.m
@@ -16,6 +16,17 @@
 
 #import "FirebaseStorageUI/Sources/Public/FirebaseStorageUI/FIRStorageDownloadTask+SDWebImage.h"
 
+// For SPM builds the header is empty (no @import, no @interface) to keep the
+// Clang module scanner happy.  Provide the full import and category declaration
+// here where @import is safe (compilation phase, not scan phase).
+#if !__has_include(<FirebaseStorage/FirebaseStorage.h>) && !__has_include(<FirebaseStorage/FirebaseStorage-Swift.h>)
+@import FirebaseStorage;
+NS_ASSUME_NONNULL_BEGIN
+@interface FIRStorageDownloadTask (SDWebImage) <SDWebImageOperation>
+@end
+NS_ASSUME_NONNULL_END
+#endif
+
 @implementation FIRStorageDownloadTask (SDWebImage)
 
 @end

--- a/FirebaseStorageUI/Sources/FUIStorageImageLoader.m
+++ b/FirebaseStorageUI/Sources/FUIStorageImageLoader.m
@@ -164,7 +164,7 @@
     }
   }];
   
-  return download;
+  return (id<SDWebImageOperation>)download;
 }
 
 - (BOOL)shouldBlockFailedURLWithURL:(NSURL *)url error:(NSError *)error {

--- a/FirebaseStorageUI/Sources/NSURL+FirebaseStorage.m
+++ b/FirebaseStorageUI/Sources/NSURL+FirebaseStorage.m
@@ -17,6 +17,14 @@
 #import "FirebaseStorageUI/Sources/Public/FirebaseStorageUI/NSURL+FirebaseStorage.h"
 #import <objc/runtime.h>
 
+#if __has_include(<FirebaseStorage/FirebaseStorage.h>)
+  #import <FirebaseStorage/FirebaseStorage.h>
+#elif __has_include(<FirebaseStorage/FirebaseStorage-Swift.h>)
+  #import <FirebaseStorage/FirebaseStorage-Swift.h>
+#else
+  @import FirebaseStorage;
+#endif
+
 @implementation NSURL (FirebaseStorage)
 
 - (FIRStorageReference *)sd_storageReference {

--- a/FirebaseStorageUI/Sources/Public/FirebaseStorageUI/FIRStorageDownloadTask+SDWebImage.h
+++ b/FirebaseStorageUI/Sources/Public/FirebaseStorageUI/FIRStorageDownloadTask+SDWebImage.h
@@ -14,22 +14,24 @@
 //  limitations under the License.
 //
 
-#if __has_include(<FirebaseStorage/FirebaseStorage.h>)
-  // Firebase 8.x
-  #import <FirebaseStorage/FirebaseStorage.h>
-#elif __has_include(<FirebaseStorage/FirebaseStorage-Swift.h>)
-  // Firebase 9.0+
-  #import <FirebaseStorage/FirebaseStorage-Swift.h>
-#else
-  @import FirebaseStorage;
-#endif
 #import <SDWebImage/SDWebImage.h>
 
-NS_ASSUME_NONNULL_BEGIN
-
-// `FIRStorageDownloadTask` conforms to `SDWebImageOperation` protocol
-@interface FIRStorageDownloadTask (SDWebImage) <SDWebImageOperation>
-
-@end
-
-NS_ASSUME_NONNULL_END
+// The category declaration requires FIRStorageDownloadTask to be fully defined,
+// which is only possible when the CocoaPods-style headers are present.
+// For SPM builds the declaration (and @import FirebaseStorage) live in the .m file
+// so the Clang module scanner never sees @import here.
+#if __has_include(<FirebaseStorage/FirebaseStorage.h>)
+  // Firebase 8.x (CocoaPods)
+  #import <FirebaseStorage/FirebaseStorage.h>
+  NS_ASSUME_NONNULL_BEGIN
+  @interface FIRStorageDownloadTask (SDWebImage) <SDWebImageOperation>
+  @end
+  NS_ASSUME_NONNULL_END
+#elif __has_include(<FirebaseStorage/FirebaseStorage-Swift.h>)
+  // Firebase 9.0+ (CocoaPods)
+  #import <FirebaseStorage/FirebaseStorage-Swift.h>
+  NS_ASSUME_NONNULL_BEGIN
+  @interface FIRStorageDownloadTask (SDWebImage) <SDWebImageOperation>
+  @end
+  NS_ASSUME_NONNULL_END
+#endif

--- a/FirebaseStorageUI/Sources/Public/FirebaseStorageUI/FUIStorageDefine.h
+++ b/FirebaseStorageUI/Sources/Public/FirebaseStorageUI/FUIStorageDefine.h
@@ -14,15 +14,6 @@
 //  limitations under the License.
 //
 
-#if __has_include(<FirebaseStorage/FirebaseStorage.h>)
-  // Firebase 8.x
-  #import <FirebaseStorage/FirebaseStorage.h>
-#elif __has_include(<FirebaseStorage/FirebaseStorage-Swift.h>)
-  // Firebase 9.0+
-  #import <FirebaseStorage/FirebaseStorage-Swift.h>
-#else
-  @import FirebaseStorage;
-#endif
 #import <SDWebImage/SDWebImage.h>
 
 /**

--- a/FirebaseStorageUI/Sources/Public/FirebaseStorageUI/NSURL+FirebaseStorage.h
+++ b/FirebaseStorageUI/Sources/Public/FirebaseStorageUI/NSURL+FirebaseStorage.h
@@ -16,13 +16,14 @@
 #import <Foundation/Foundation.h>
 
 #if __has_include(<FirebaseStorage/FirebaseStorage.h>)
-  // Firebase 8.x
+  // Firebase 8.x (CocoaPods)
   #import <FirebaseStorage/FirebaseStorage.h>
 #elif __has_include(<FirebaseStorage/FirebaseStorage-Swift.h>)
-  // Firebase 9.0+
+  // Firebase 9.0+ (CocoaPods)
   #import <FirebaseStorage/FirebaseStorage-Swift.h>
 #else
-  @import FirebaseStorage;
+  // Swift Package Manager: forward declaration only.
+  @class FIRStorageReference;
 #endif
 
 NS_ASSUME_NONNULL_BEGIN

--- a/FirebaseStorageUI/Sources/Public/FirebaseStorageUI/UIImageView+FirebaseStorage.h
+++ b/FirebaseStorageUI/Sources/Public/FirebaseStorageUI/UIImageView+FirebaseStorage.h
@@ -17,21 +17,18 @@
 #import <UIKit/UIKit.h>
 
 #if __has_include(<FirebaseStorage/FirebaseStorage.h>)
-  // Firebase 8.x
+  // Firebase 8.x (CocoaPods)
   #import <FirebaseStorage/FirebaseStorage.h>
 #elif (__has_include(<FirebaseStorage/FirebaseStorage-Swift.h>))
-  // Firebase 9.0+
+  // Firebase 9.0+ (CocoaPods)
   #import <FirebaseStorage/FirebaseStorage-Swift.h>
 #else
-  // If you're using FirebaseStorageUI via Swift Package Manager
-  // from a Swift or mixed Swift/ObjC build target, you will need
-  // to add
-  // -Xcc -fmodule-map-file=$(GENERATED_MODULEMAP_DIR)/FirebaseStorage.modulemap
-  // to your target's Other Swift Flags build setting.
-  // See
-  // https://github.com/firebase/FirebaseUI-iOS/issues/1028#issuecomment-1262689219
-  // for more details.
-  @import FirebaseStorage;
+  // Swift Package Manager: forward declarations only to avoid Clang module-scanner
+  // failures. Your app target must `@import FirebaseStorage` (or `import FirebaseStorage`
+  // in Swift) separately.
+  @class FIRStorage;
+  @class FIRStorageReference;
+  @class FIRStorageDownloadTask;
 #endif
 #import <SDWebImage/SDWebImage.h>
 

--- a/FirebaseStorageUI/Sources/UIImageView+FirebaseStorage.m
+++ b/FirebaseStorageUI/Sources/UIImageView+FirebaseStorage.m
@@ -17,6 +17,14 @@
 #import "FirebaseStorageUI/Sources/Public/FirebaseStorageUI/UIImageView+FirebaseStorage.h"
 #import "FirebaseStorageUI/Sources/Public/FirebaseStorageUI/FUIStorageImageLoader.h"
 
+#if __has_include(<FirebaseStorage/FirebaseStorage.h>)
+  #import <FirebaseStorage/FirebaseStorage.h>
+#elif __has_include(<FirebaseStorage/FirebaseStorage-Swift.h>)
+  #import <FirebaseStorage/FirebaseStorage-Swift.h>
+#else
+  @import FirebaseStorage;
+#endif
+
 @implementation UIImageView (FirebaseStorage)
 
 - (void)sd_setImageWithStorageReference:(FIRStorageReference *)storageRef {


### PR DESCRIPTION
Fixes #1271

FirebaseStorage 9+ is pure Swift with no ObjC umbrella headers. Using `@import FirebaseStorage` in public headers caused the Clang dependency scanner to fail before compilation even begins.

Replace `@import` in public headers with `@class` forward declarations and move the actual imports into `.m` files.