### PR TITLE
build(deps): dependabot cooldown configs / supply-chain hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    cooldown:
+      default-days: 7
+      semver-major-days: 7
+      semver-minor-days: 7
+      semver-patch-days: 7
     labels:
       - 'dependencies'
 
@@ -11,6 +16,11 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    cooldown:
+      default-days: 7
+      semver-major-days: 7
+      semver-minor-days: 7
+      semver-patch-days: 7
     labels:
       - 'dependencies'
 
@@ -18,5 +28,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    cooldown:
+      default-days: 7
     labels:
       - 'dependencies'


### PR DESCRIPTION
Add 7-day dependabot cooldown per ecosystem support rules: semver params for Swift and Bundler, `default-days` only for GitHub Actions.

- Related #1354