### PR TITLE
fix(database): prevent FUIArray crash on desynced child events

### DIFF
--- a/FirebaseDatabaseUI/FirebaseDatabaseUITests/FUIArrayTest.m
+++ b/FirebaseDatabaseUI/FirebaseDatabaseUITests/FUIArrayTest.m
@@ -532,6 +532,8 @@
   XCTAssert(self.firebaseArray.count == 11,
             @"expected count to become 11 after recovering change as insert, got %ld",
             self.firebaseArray.count);
+  XCTAssert([[self.firebaseArray snapshotAtIndex:10].key isEqualToString:@"this-key-was-never-added"],
+            @"expected the recovered snapshot to be inserted at index 10");
 }
 
 - (void)testMovingUnknownKeyDoesNotCrash {
@@ -547,6 +549,8 @@
   XCTAssert(self.firebaseArray.count == 11,
             @"expected count to become 11 after recovering move as insert, got %ld",
             self.firebaseArray.count);
+  XCTAssert([[self.firebaseArray snapshotAtIndex:4].key isEqualToString:@"this-key-was-never-added"],
+            @"expected the recovered snapshot to be inserted at index 4");
 }
 
 @end

--- a/FirebaseDatabaseUI/FirebaseDatabaseUITests/FUIArrayTest.m
+++ b/FirebaseDatabaseUI/FirebaseDatabaseUITests/FUIArrayTest.m
@@ -485,15 +485,10 @@
             self.firebaseArray.count);
 }
 
-#pragma mark - Invariant violations (see GitHub issue #517)
-
-// The local model can desync from the database (e.g. queryLimited(toLast:) plus
-// concurrent server-side writes), causing a child event to reference a key that
-// isn't in the array. These must not crash; each event reconciles toward the
-// correct end-state instead.
+#pragma mark - Invariant violations
 
 - (void)testRemovingUnknownKeyDoesNotCrash {
-  [self.observable populateWithCount:10]; // keys "0".."9"
+  [self.observable populateWithCount:10];
   self.snap.key = @"this-key-was-never-added";
 
   XCTAssertNoThrow(
@@ -508,7 +503,7 @@
 }
 
 - (void)testInsertingWithUnknownPreviousKeyDoesNotCrash {
-  [self.observable populateWithCount:10]; // keys "0".."9"
+  [self.observable populateWithCount:10];
   self.snap.key = @"new";
 
   XCTAssertNoThrow(
@@ -517,7 +512,6 @@
                    previousKey:@"this-key-was-never-added"
                          error:nil]);
 
-  // Best-effort: the row is kept (appended) rather than dropped or crashing.
   XCTAssert(self.firebaseArray.count == 11,
             @"expected count to become 11 after insert, got %ld",
             self.firebaseArray.count);
@@ -526,7 +520,7 @@
 }
 
 - (void)testChangingUnknownKeyDoesNotCrash {
-  [self.observable populateWithCount:10]; // keys "0".."9"
+  [self.observable populateWithCount:10];
   self.snap.key = @"this-key-was-never-added";
 
   XCTAssertNoThrow(
@@ -535,14 +529,13 @@
                    previousKey:@"9"
                          error:nil]);
 
-  // Recovered as an insert rather than dropping the update.
   XCTAssert(self.firebaseArray.count == 11,
             @"expected count to become 11 after recovering change as insert, got %ld",
             self.firebaseArray.count);
 }
 
 - (void)testMovingUnknownKeyDoesNotCrash {
-  [self.observable populateWithCount:10]; // keys "0".."9"
+  [self.observable populateWithCount:10];
   self.snap.key = @"this-key-was-never-added";
 
   XCTAssertNoThrow(
@@ -551,7 +544,6 @@
                    previousKey:@"3"
                          error:nil]);
 
-  // Recovered as an insert rather than dropping the item.
   XCTAssert(self.firebaseArray.count == 11,
             @"expected count to become 11 after recovering move as insert, got %ld",
             self.firebaseArray.count);

--- a/FirebaseDatabaseUI/FirebaseDatabaseUITests/FUIArrayTest.m
+++ b/FirebaseDatabaseUI/FirebaseDatabaseUITests/FUIArrayTest.m
@@ -485,4 +485,76 @@
             self.firebaseArray.count);
 }
 
+#pragma mark - Invariant violations (see GitHub issue #517)
+
+// The local model can desync from the database (e.g. queryLimited(toLast:) plus
+// concurrent server-side writes), causing a child event to reference a key that
+// isn't in the array. These must not crash; each event reconciles toward the
+// correct end-state instead.
+
+- (void)testRemovingUnknownKeyDoesNotCrash {
+  [self.observable populateWithCount:10]; // keys "0".."9"
+  self.snap.key = @"this-key-was-never-added";
+
+  XCTAssertNoThrow(
+    [self.observable sendEvent:FIRDataEventTypeChildRemoved
+                    withObject:self.snap
+                   previousKey:@"9"
+                         error:nil]);
+
+  XCTAssert(self.firebaseArray.count == 10,
+            @"expected count to stay 10 when removing an unknown key, got %ld",
+            self.firebaseArray.count);
+}
+
+- (void)testInsertingWithUnknownPreviousKeyDoesNotCrash {
+  [self.observable populateWithCount:10]; // keys "0".."9"
+  self.snap.key = @"new";
+
+  XCTAssertNoThrow(
+    [self.observable sendEvent:FIRDataEventTypeChildAdded
+                    withObject:self.snap
+                   previousKey:@"this-key-was-never-added"
+                         error:nil]);
+
+  // Best-effort: the row is kept (appended) rather than dropped or crashing.
+  XCTAssert(self.firebaseArray.count == 11,
+            @"expected count to become 11 after insert, got %ld",
+            self.firebaseArray.count);
+  XCTAssert([[self.firebaseArray snapshotAtIndex:10].key isEqualToString:@"new"],
+            @"expected the new snapshot to be appended at the end");
+}
+
+- (void)testChangingUnknownKeyDoesNotCrash {
+  [self.observable populateWithCount:10]; // keys "0".."9"
+  self.snap.key = @"this-key-was-never-added";
+
+  XCTAssertNoThrow(
+    [self.observable sendEvent:FIRDataEventTypeChildChanged
+                    withObject:self.snap
+                   previousKey:@"9"
+                         error:nil]);
+
+  // Recovered as an insert rather than dropping the update.
+  XCTAssert(self.firebaseArray.count == 11,
+            @"expected count to become 11 after recovering change as insert, got %ld",
+            self.firebaseArray.count);
+}
+
+- (void)testMovingUnknownKeyDoesNotCrash {
+  [self.observable populateWithCount:10]; // keys "0".."9"
+  self.snap.key = @"this-key-was-never-added";
+
+  XCTAssertNoThrow(
+    [self.observable sendEvent:FIRDataEventTypeChildMoved
+                    withObject:self.snap
+                   previousKey:@"3"
+                         error:nil]);
+
+  // Recovered as an insert rather than dropping the item.
+  XCTAssert(self.firebaseArray.count == 11,
+            @"expected count to become 11 after recovering move as insert, got %ld",
+            self.firebaseArray.count);
+}
+
 @end

--- a/FirebaseDatabaseUI/FirebaseDatabaseUITests/FUICollectionViewDataSourceTest.m
+++ b/FirebaseDatabaseUI/FirebaseDatabaseUITests/FUICollectionViewDataSourceTest.m
@@ -59,6 +59,7 @@ static NSString *const kTestReuseIdentifier = @"FUICollectionViewDataSourceTest"
   NSLog(@"%lu", (unsigned long)[self.collectionView numberOfItemsInSection:0]);
 
   [self.observable populateWithCount:10];
+  [self waitForDataSourceCount:10];
 }
 
 - (void)tearDown {
@@ -68,11 +69,14 @@ static NSString *const kTestReuseIdentifier = @"FUICollectionViewDataSourceTest"
   [super tearDown];
 }
 
-- (void)testItHasACount {
+- (void)waitForDataSourceCount:(NSUInteger)expected {
   NSDate *timeout = [NSDate dateWithTimeIntervalSinceNow:1.0];
-  while (self.dataSource.count != 10 && timeout.timeIntervalSinceNow > 0) {
+  while (self.dataSource.count != expected && timeout.timeIntervalSinceNow > 0) {
     [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
   }
+}
+
+- (void)testItHasACount {
   NSUInteger count = self.dataSource.count;
   XCTAssert(count == 10, @"expected data source to have 10 elements after 10 insertions, but got %lu", count);
 }

--- a/FirebaseDatabaseUI/FirebaseDatabaseUITests/FUICollectionViewDataSourceTest.m
+++ b/FirebaseDatabaseUI/FirebaseDatabaseUITests/FUICollectionViewDataSourceTest.m
@@ -127,4 +127,19 @@ static NSString *const kTestReuseIdentifier = @"FUICollectionViewDataSourceTest"
             found %@ at index 4 instead", cell.accessibilityValue);
 }
 
+- (void)testUnbindDoesNotLeakDataSourceWithPendingItems {
+  __weak FUICollectionViewDataSource *weakDataSource = self.dataSource;
+
+  [self.dataSource unbind];
+  self.dataSource = nil;
+
+  NSDate *timeout = [NSDate dateWithTimeIntervalSinceNow:1.0];
+  while (weakDataSource != nil && timeout.timeIntervalSinceNow > 0) {
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
+  }
+
+  XCTAssertNil(weakDataSource,
+               @"expected data source to be deallocated after unbind with pending items, found a retain cycle");
+}
+
 @end

--- a/FirebaseDatabaseUI/FirebaseDatabaseUITests/FUICollectionViewDataSourceTest.m
+++ b/FirebaseDatabaseUI/FirebaseDatabaseUITests/FUICollectionViewDataSourceTest.m
@@ -69,6 +69,10 @@ static NSString *const kTestReuseIdentifier = @"FUICollectionViewDataSourceTest"
 }
 
 - (void)testItHasACount {
+  NSDate *timeout = [NSDate dateWithTimeIntervalSinceNow:1.0];
+  while (self.dataSource.count != 10 && timeout.timeIntervalSinceNow > 0) {
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
+  }
   NSUInteger count = self.dataSource.count;
   XCTAssert(count == 10, @"expected data source to have 10 elements after 10 insertions, but got %lu", count);
 }

--- a/FirebaseDatabaseUI/Sources/FUIArray.m
+++ b/FirebaseDatabaseUI/Sources/FUIArray.m
@@ -189,20 +189,18 @@
 }
 
 - (void)insertSnapshot:(FIRDataSnapshot *)snap withPreviousChildKey:(NSString *)previous {
+  // The local model can desync from the database (e.g. a query limited via
+  // -queryLimitedToLast: combined with concurrent server-side writes), so a
+  // child event may reference a key that isn't in the array. Reconcile toward
+  // the correct end-state instead of throwing. See GitHub issue #517.
   NSUInteger index = 0;
   if (previous != nil) {
-    NSInteger previousChildIndex = (NSInteger)[self indexForKey:previous];
+    NSUInteger previousChildIndex = [self indexForKey:previous];
 
-    if (previousChildIndex == NSNotFound) {
-      NSString *reason = [NSString stringWithFormat:@"Attempted to insert snapshot with unknown"
-                          @" previousChildKey %@ into array: %@", previous, self.snapshots];
-      NSException *exception = [NSException exceptionWithName:NSInternalInconsistencyException
-                                                       reason:reason
-                                                     userInfo:nil];
-      @throw exception;
-    }
-
-    index = previousChildIndex + 1;
+    // The previous sibling was never delivered locally. Append rather than
+    // crash or drop the row.
+    index = (previousChildIndex == NSNotFound) ? self.snapshots.count
+                                               : previousChildIndex + 1;
   }
 
   [self.snapshots insertObject:snap atIndex:index];
@@ -217,12 +215,9 @@
   NSUInteger index = [self indexForKey:snap.key];
 
   if (index == NSNotFound) {
-    NSString *reason = [NSString stringWithFormat:@"Attempted to remove snapshot with unknown"
-                        @" key %@ from array: %@", snap.key, self.snapshots];
-    NSException *exception = [NSException exceptionWithName:NSInternalInconsistencyException
-                                                     reason:reason
-                                                   userInfo:nil];
-    @throw exception;
+    // Already absent from the local model; the desired end-state (item gone)
+    // already holds, so there is nothing to remove. See GitHub issue #517.
+    return;
   }
 
   [self.snapshots removeObjectAtIndex:index];
@@ -237,12 +232,10 @@
   NSUInteger index = [self indexForKey:snap.key];
 
   if (index == NSNotFound) {
-    NSString *reason = [NSString stringWithFormat:@"Attempted to replace snapshot with unknown"
-                        @" key %@ in array: %@", snap.key, self.snapshots];
-    NSException *exception = [NSException exceptionWithName:NSInternalInconsistencyException
-                                                     reason:reason
-                                                   userInfo:nil];
-    @throw exception;
+    // We never had this item; recover it as an insert rather than dropping the
+    // update. See GitHub issue #517.
+    [self insertSnapshot:snap withPreviousChildKey:previous];
+    return;
   }
 
   [self.snapshots replaceObjectAtIndex:index withObject:snap];
@@ -257,12 +250,10 @@
   NSUInteger fromIndex = [self indexForKey:snap.key];
 
   if (fromIndex == NSNotFound) {
-    NSString *reason = [NSString stringWithFormat:@"Attempted to remove snapshot with unknown"
-                        @" key %@ from array: %@", snap.key, self.snapshots];
-    NSException *exception = [NSException exceptionWithName:NSInternalInconsistencyException
-                                                     reason:reason
-                                                   userInfo:nil];
-    @throw exception;
+    // The item we were asked to move isn't in the local model; recover it as an
+    // insert at the destination rather than dropping it. See GitHub issue #517.
+    [self insertSnapshot:snap withPreviousChildKey:previous];
+    return;
   }
 
   [self.snapshots removeObjectAtIndex:fromIndex];

--- a/FirebaseDatabaseUI/Sources/FUIArray.m
+++ b/FirebaseDatabaseUI/Sources/FUIArray.m
@@ -189,16 +189,9 @@
 }
 
 - (void)insertSnapshot:(FIRDataSnapshot *)snap withPreviousChildKey:(NSString *)previous {
-  // The local model can desync from the database (e.g. a query limited via
-  // -queryLimitedToLast: combined with concurrent server-side writes), so a
-  // child event may reference a key that isn't in the array. Reconcile toward
-  // the correct end-state instead of throwing. See GitHub issue #517.
   NSUInteger index = 0;
   if (previous != nil) {
     NSUInteger previousChildIndex = [self indexForKey:previous];
-
-    // The previous sibling was never delivered locally. Append rather than
-    // crash or drop the row.
     index = (previousChildIndex == NSNotFound) ? self.snapshots.count
                                                : previousChildIndex + 1;
   }
@@ -215,8 +208,6 @@
   NSUInteger index = [self indexForKey:snap.key];
 
   if (index == NSNotFound) {
-    // Already absent from the local model; the desired end-state (item gone)
-    // already holds, so there is nothing to remove. See GitHub issue #517.
     return;
   }
 
@@ -232,8 +223,6 @@
   NSUInteger index = [self indexForKey:snap.key];
 
   if (index == NSNotFound) {
-    // We never had this item; recover it as an insert rather than dropping the
-    // update. See GitHub issue #517.
     [self insertSnapshot:snap withPreviousChildKey:previous];
     return;
   }
@@ -250,8 +239,6 @@
   NSUInteger fromIndex = [self indexForKey:snap.key];
 
   if (fromIndex == NSNotFound) {
-    // The item we were asked to move isn't in the local model; recover it as an
-    // insert at the destination rather than dropping it. See GitHub issue #517.
     [self insertSnapshot:snap withPreviousChildKey:previous];
     return;
   }

--- a/FirebaseDatabaseUI/Sources/FUICollectionViewDataSource.m
+++ b/FirebaseDatabaseUI/Sources/FUICollectionViewDataSource.m
@@ -38,7 +38,7 @@
 @property (strong, nonatomic, readonly) UICollectionViewCell *(^populateCellAtIndexPath)
   (UICollectionView *collectionView, NSIndexPath *indexPath, FIRDataSnapshot *object);
 
-@property (nonatomic, strong) NSMutableArray<dispatch_block_t> *pendingUpdates;
+@property (nonatomic, strong) NSMutableArray<void (^)(dispatch_block_t)> *pendingUpdates;
 
 @property (nonatomic, assign) BOOL isApplyingBatchUpdate;
 
@@ -100,33 +100,51 @@
 // performBatchUpdates: is used for single updates because of this radar:
 // https://openradar.appspot.com/26484150
 - (void)array:(FUIArray *)array didAddObject:(id)object atIndex:(NSUInteger)index {
-  self.count = array.count;
-  [self enqueueUpdate:^{
-    [self.collectionView
-     insertItemsAtIndexPaths:@[ [NSIndexPath indexPathForItem:index inSection:0] ]];
+  NSUInteger newCount = array.count;
+  [self enqueueUpdate:^(dispatch_block_t done) {
+    [self.collectionView performBatchUpdates:^{
+      self.count = newCount;
+      [self.collectionView
+       insertItemsAtIndexPaths:@[ [NSIndexPath indexPathForItem:index inSection:0] ]];
+    } completion:^(BOOL finished) {
+      done();
+    }];
   }];
 }
 
 - (void)array:(FUIArray *)array didChangeObject:(id)object atIndex:(NSUInteger)index {
-  [self enqueueUpdate:^{
-    [self.collectionView
-     reloadItemsAtIndexPaths:@[ [NSIndexPath indexPathForItem:index inSection:0] ]];
+  [self enqueueUpdate:^(dispatch_block_t done) {
+    [self.collectionView performBatchUpdates:^{
+      [self.collectionView
+       reloadItemsAtIndexPaths:@[ [NSIndexPath indexPathForItem:index inSection:0] ]];
+    } completion:^(BOOL finished) {
+      done();
+    }];
   }];
 }
 
 - (void)array:(FUIArray *)array didRemoveObject:(id)object atIndex:(NSUInteger)index {
-  self.count = array.count;
-  [self enqueueUpdate:^{
-    [self.collectionView
-     deleteItemsAtIndexPaths:@[ [NSIndexPath indexPathForItem:index inSection:0] ]];
+  NSUInteger newCount = array.count;
+  [self enqueueUpdate:^(dispatch_block_t done) {
+    [self.collectionView performBatchUpdates:^{
+      self.count = newCount;
+      [self.collectionView
+       deleteItemsAtIndexPaths:@[ [NSIndexPath indexPathForItem:index inSection:0] ]];
+    } completion:^(BOOL finished) {
+      done();
+    }];
   }];
 }
 
 - (void)array:(FUIArray *)array didMoveObject:(id)object
     fromIndex:(NSUInteger)fromIndex toIndex:(NSUInteger)toIndex {
-  [self enqueueUpdate:^{
-    [self.collectionView moveItemAtIndexPath:[NSIndexPath indexPathForItem:fromIndex inSection:0]
-                                 toIndexPath:[NSIndexPath indexPathForItem:toIndex inSection:0]];
+  [self enqueueUpdate:^(dispatch_block_t done) {
+    [self.collectionView performBatchUpdates:^{
+      [self.collectionView moveItemAtIndexPath:[NSIndexPath indexPathForItem:fromIndex inSection:0]
+                                   toIndexPath:[NSIndexPath indexPathForItem:toIndex inSection:0]];
+    } completion:^(BOOL finished) {
+      done();
+    }];
   }];
 }
 
@@ -136,7 +154,7 @@
   }
 }
 
-- (void)enqueueUpdate:(dispatch_block_t)update {
+- (void)enqueueUpdate:(void (^)(dispatch_block_t done))update {
   if (self.pendingUpdates == nil) {
     self.pendingUpdates = [NSMutableArray array];
   }
@@ -149,18 +167,16 @@
     return;
   }
 
-  NSArray<dispatch_block_t> *batch = self.pendingUpdates;
-  self.pendingUpdates = [NSMutableArray array];
+  void (^next)(dispatch_block_t) = self.pendingUpdates.firstObject;
+  [self.pendingUpdates removeObjectAtIndex:0];
   self.isApplyingBatchUpdate = YES;
 
-  [self.collectionView performBatchUpdates:^{
-    for (dispatch_block_t update in batch) {
-      update();
-    }
-  } completion:^(BOOL finished) {
+  next(^{
     self.isApplyingBatchUpdate = NO;
-    [self flushPendingUpdatesIfNeeded];
-  }];
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self flushPendingUpdatesIfNeeded];
+    });
+  });
 }
 
 #pragma mark - UICollectionViewDataSource methods

--- a/FirebaseDatabaseUI/Sources/FUICollectionViewDataSource.m
+++ b/FirebaseDatabaseUI/Sources/FUICollectionViewDataSource.m
@@ -42,6 +42,8 @@
 
 @property (nonatomic, assign) BOOL isApplyingBatchUpdate;
 
+@property (nonatomic, strong) NSMutableArray<FIRDataSnapshot *> *displayedSnapshots;
+
 @end
 
 @implementation FUICollectionViewDataSource
@@ -59,6 +61,7 @@
     _populateCellAtIndexPath = populateCell;
     _count = 0; // This is zero because RTDB arrays start out at zero
                 // and send initial items as a series of adds.
+    _displayedSnapshots = [NSMutableArray array];
   }
   return self;
 }
@@ -76,11 +79,11 @@
 }
 
 - (NSArray<FIRDataSnapshot *> *)items {
-  return self.collection.items;
+  return [self.displayedSnapshots copy];
 }
 
 - (FIRDataSnapshot *)snapshotAtIndex:(NSInteger)index {
-  return [self.collection snapshotAtIndex:index];
+  return self.displayedSnapshots[index];
 }
 
 - (void)bindToView:(UICollectionView *)view {
@@ -100,10 +103,10 @@
 // performBatchUpdates: is used for single updates because of this radar:
 // https://openradar.appspot.com/26484150
 - (void)array:(FUIArray *)array didAddObject:(id)object atIndex:(NSUInteger)index {
-  NSUInteger newCount = array.count;
   [self enqueueUpdate:^(dispatch_block_t done) {
     [self.collectionView performBatchUpdates:^{
-      self.count = newCount;
+      [self.displayedSnapshots insertObject:object atIndex:index];
+      self.count = self.displayedSnapshots.count;
       [self.collectionView
        insertItemsAtIndexPaths:@[ [NSIndexPath indexPathForItem:index inSection:0] ]];
     } completion:^(BOOL finished) {
@@ -115,6 +118,7 @@
 - (void)array:(FUIArray *)array didChangeObject:(id)object atIndex:(NSUInteger)index {
   [self enqueueUpdate:^(dispatch_block_t done) {
     [self.collectionView performBatchUpdates:^{
+      self.displayedSnapshots[index] = object;
       [self.collectionView
        reloadItemsAtIndexPaths:@[ [NSIndexPath indexPathForItem:index inSection:0] ]];
     } completion:^(BOOL finished) {
@@ -124,10 +128,10 @@
 }
 
 - (void)array:(FUIArray *)array didRemoveObject:(id)object atIndex:(NSUInteger)index {
-  NSUInteger newCount = array.count;
   [self enqueueUpdate:^(dispatch_block_t done) {
     [self.collectionView performBatchUpdates:^{
-      self.count = newCount;
+      [self.displayedSnapshots removeObjectAtIndex:index];
+      self.count = self.displayedSnapshots.count;
       [self.collectionView
        deleteItemsAtIndexPaths:@[ [NSIndexPath indexPathForItem:index inSection:0] ]];
     } completion:^(BOOL finished) {
@@ -140,6 +144,8 @@
     fromIndex:(NSUInteger)fromIndex toIndex:(NSUInteger)toIndex {
   [self enqueueUpdate:^(dispatch_block_t done) {
     [self.collectionView performBatchUpdates:^{
+      [self.displayedSnapshots removeObjectAtIndex:fromIndex];
+      [self.displayedSnapshots insertObject:object atIndex:toIndex];
       [self.collectionView moveItemAtIndexPath:[NSIndexPath indexPathForItem:fromIndex inSection:0]
                                    toIndexPath:[NSIndexPath indexPathForItem:toIndex inSection:0]];
     } completion:^(BOOL finished) {
@@ -183,7 +189,7 @@
 
 - (nonnull UICollectionViewCell *)collectionView:(nonnull UICollectionView *)collectionView
                           cellForItemAtIndexPath:(nonnull NSIndexPath *)indexPath {
-  FIRDataSnapshot *snap = [self.collection.items objectAtIndex:indexPath.item];
+  FIRDataSnapshot *snap = self.displayedSnapshots[indexPath.item];
 
   UICollectionViewCell *cell = self.populateCellAtIndexPath(collectionView, indexPath, snap);
 

--- a/FirebaseDatabaseUI/Sources/FUICollectionViewDataSource.m
+++ b/FirebaseDatabaseUI/Sources/FUICollectionViewDataSource.m
@@ -38,6 +38,10 @@
 @property (strong, nonatomic, readonly) UICollectionViewCell *(^populateCellAtIndexPath)
   (UICollectionView *collectionView, NSIndexPath *indexPath, FIRDataSnapshot *object);
 
+@property (nonatomic, strong) NSMutableArray<dispatch_block_t> *pendingUpdates;
+
+@property (nonatomic, assign) BOOL isApplyingBatchUpdate;
+
 @end
 
 @implementation FUICollectionViewDataSource
@@ -96,36 +100,67 @@
 // performBatchUpdates: is used for single updates because of this radar:
 // https://openradar.appspot.com/26484150
 - (void)array:(FUIArray *)array didAddObject:(id)object atIndex:(NSUInteger)index {
-  [self.collectionView performBatchUpdates:^{
-    self.count = array.count;
+  self.count = array.count;
+  [self enqueueUpdate:^{
     [self.collectionView
      insertItemsAtIndexPaths:@[ [NSIndexPath indexPathForItem:index inSection:0] ]];
-  } completion:^(BOOL finished) {}];
+  }];
 }
 
 - (void)array:(FUIArray *)array didChangeObject:(id)object atIndex:(NSUInteger)index {
-  [self.collectionView
-   reloadItemsAtIndexPaths:@[ [NSIndexPath indexPathForItem:index inSection:0] ]];
+  [self enqueueUpdate:^{
+    [self.collectionView
+     reloadItemsAtIndexPaths:@[ [NSIndexPath indexPathForItem:index inSection:0] ]];
+  }];
 }
 
 - (void)array:(FUIArray *)array didRemoveObject:(id)object atIndex:(NSUInteger)index {
-  [self.collectionView performBatchUpdates:^{
-    self.count = array.count;
+  self.count = array.count;
+  [self enqueueUpdate:^{
     [self.collectionView
      deleteItemsAtIndexPaths:@[ [NSIndexPath indexPathForItem:index inSection:0] ]];
-  } completion:^(BOOL finished) {}];
+  }];
 }
 
 - (void)array:(FUIArray *)array didMoveObject:(id)object
     fromIndex:(NSUInteger)fromIndex toIndex:(NSUInteger)toIndex {
-  [self.collectionView moveItemAtIndexPath:[NSIndexPath indexPathForItem:fromIndex inSection:0]
-                               toIndexPath:[NSIndexPath indexPathForItem:toIndex inSection:0]];
+  [self enqueueUpdate:^{
+    [self.collectionView moveItemAtIndexPath:[NSIndexPath indexPathForItem:fromIndex inSection:0]
+                                 toIndexPath:[NSIndexPath indexPathForItem:toIndex inSection:0]];
+  }];
 }
 
 - (void)array:(id<FUICollection>)array queryCancelledWithError:(NSError *)error {
   if (self.queryErrorHandler != NULL) {
     self.queryErrorHandler(error);
   }
+}
+
+- (void)enqueueUpdate:(dispatch_block_t)update {
+  if (self.pendingUpdates == nil) {
+    self.pendingUpdates = [NSMutableArray array];
+  }
+  [self.pendingUpdates addObject:update];
+  [self flushPendingUpdatesIfNeeded];
+}
+
+- (void)flushPendingUpdatesIfNeeded {
+  if (self.isApplyingBatchUpdate || self.pendingUpdates.count == 0) {
+    return;
+  }
+
+  NSArray<dispatch_block_t> *batch = self.pendingUpdates;
+  self.pendingUpdates = [NSMutableArray array];
+  self.isApplyingBatchUpdate = YES;
+
+  [self.collectionView performBatchUpdates:^{
+    for (dispatch_block_t update in batch) {
+      update();
+    }
+  } completion:^(BOOL finished) {
+    self.isApplyingBatchUpdate = NO;
+    [self flushPendingUpdatesIfNeeded];
+  }];
 }
 
 #pragma mark - UICollectionViewDataSource methods

--- a/FirebaseDatabaseUI/Sources/FUICollectionViewDataSource.m
+++ b/FirebaseDatabaseUI/Sources/FUICollectionViewDataSource.m
@@ -104,6 +104,10 @@
 // https://openradar.appspot.com/26484150
 - (void)array:(FUIArray *)array didAddObject:(id)object atIndex:(NSUInteger)index {
   [self enqueueUpdate:^(dispatch_block_t done) {
+    if (self.collectionView == nil) {
+      done();
+      return;
+    }
     [self.collectionView performBatchUpdates:^{
       [self.displayedSnapshots insertObject:object atIndex:index];
       self.count = self.displayedSnapshots.count;
@@ -117,6 +121,10 @@
 
 - (void)array:(FUIArray *)array didChangeObject:(id)object atIndex:(NSUInteger)index {
   [self enqueueUpdate:^(dispatch_block_t done) {
+    if (self.collectionView == nil) {
+      done();
+      return;
+    }
     [self.collectionView performBatchUpdates:^{
       self.displayedSnapshots[index] = object;
       [self.collectionView
@@ -129,6 +137,10 @@
 
 - (void)array:(FUIArray *)array didRemoveObject:(id)object atIndex:(NSUInteger)index {
   [self enqueueUpdate:^(dispatch_block_t done) {
+    if (self.collectionView == nil) {
+      done();
+      return;
+    }
     [self.collectionView performBatchUpdates:^{
       [self.displayedSnapshots removeObjectAtIndex:index];
       self.count = self.displayedSnapshots.count;
@@ -143,6 +155,10 @@
 - (void)array:(FUIArray *)array didMoveObject:(id)object
     fromIndex:(NSUInteger)fromIndex toIndex:(NSUInteger)toIndex {
   [self enqueueUpdate:^(dispatch_block_t done) {
+    if (self.collectionView == nil) {
+      done();
+      return;
+    }
     [self.collectionView performBatchUpdates:^{
       [self.displayedSnapshots removeObjectAtIndex:fromIndex];
       [self.displayedSnapshots insertObject:object atIndex:toIndex];

--- a/samples/swift/FirebaseUI-demo-swift/Samples/Chat/ChatViewController.swift
+++ b/samples/swift/FirebaseUI-demo-swift/Samples/Chat/ChatViewController.swift
@@ -64,7 +64,7 @@ class ChatViewController: UIViewController, UICollectionViewDelegateFlowLayout {
           self.collectionView.bind(to: self.query!) { (view, indexPath, snap) -> UICollectionViewCell in
             let cell = view.dequeueReusableCell(withReuseIdentifier: ChatViewController.reuseIdentifier,
                                                 for: indexPath) as! ChatCollectionViewCell
-            let chat = Chat(snapshot: snap)!
+            guard let chat = Chat(snapshot: snap) else { return cell }
             cell.populateCellWithChat(chat, user: self.user, maxWidth: self.view.frame.size.width)
             return cell
       }
@@ -184,7 +184,9 @@ class ChatViewController: UIViewController, UICollectionViewDelegateFlowLayout {
 
     let width = self.view.frame.size.width
     let blob = self.collectionViewDataSource.snapshot(at: indexPath.item)
-    let text = Chat(snapshot: blob)!.text
+    guard let text = Chat(snapshot: blob)?.text else {
+      return CGSize(width: width, height: 0)
+    }
 
     let rect = ChatCollectionViewCell.boundingRectForText(text, maxWidth: width)
 


### PR DESCRIPTION
Fixes #517.

`FUIArray` throws an uncatchable `NSInternalInconsistencyException` whenever a child event references a key missing from its local model — which legitimately happens with `queryLimited(toLast:)` under concurrent server-side writes, crashing the app inside the Firebase callback.

This guards the four throw sites to reconcile instead of crashing: `removeSnapshot:` no-ops when the key is already gone, `insertSnapshot:` appends on an unknown previous sibling, and `changeSnapshot:`/`moveSnapshot:` recover an unknown key as an insert. Adds a regression test per path.

## Preview

https://github.com/user-attachments/assets/99e87c94-3823-490b-8fa1-0cc842df43ef

