### PR TITLE
docs(okf): fix root-relative paths in okf-bundle index

### DIFF
--- a/okf-bundle/ci-workflows/uikit-modules.md
+++ b/okf-bundle/ci-workflows/uikit-modules.md
@@ -14,7 +14,7 @@ Workflows (same job shape):
 * [`.github/workflows/firestore.yml`](../../.github/workflows/firestore.yml)
 * [`.github/workflows/storage.yml`](../../.github/workflows/storage.yml)
 
-Local mirror for the CocoaPods test job: [`./test.sh <Module>`](../../test.sh) after `bundle exec pod install` in the module directory — [running tests](../testing/running-tests.md#uikit-module-tests).
+Local mirror for the CocoaPods test job: [`./test.sh <Module>`](../../test.sh) after `bundle exec pod install` in the module directory — [running tests](../testing/running-tests.md#uikit-module-tests-cocoapods).
 
 ## Jobs (per module)
 

--- a/okf-bundle/index.md
+++ b/okf-bundle/index.md
@@ -6,27 +6,27 @@ okf_version: '0.1'
 
 Agent-oriented knowledge for this repository. Prefer these docs over improvised shell diagnostics or copying patterns from other FirebaseUI / React Native Firebase repos without re-deriving commands from this tree.
 
-- [Documentation/commit policy](documentation-policy.md) — durable vs ephemeral, commits as documentation, PR titles, OKF consistency
+- [Documentation/commit policy](/documentation-policy.md) — durable vs ephemeral, commits as documentation, PR titles, OKF consistency
 
 # Testing
 
-- [Agent command policy](testing/agent-command-policy.md) — allowlisted shell commands (install, lint, unit, integration, UI, CocoaPods)
-- [Change authoring workflow](testing/change-authoring-workflow.md) — verified change loop (unit-focused → area-focused review → commit); [§ validation evidence (blocking)](testing/change-authoring-workflow.md#validation-evidence-blocking)
-- [Iteration vocabulary](testing/iteration-vocabulary.md) — work type, tier, and queue field identifiers
-- [Running tests](testing/running-tests.md) — canonical SwiftUI and UIKit test commands, narrowing, emulator
-- [Validation checklist](testing/validation-checklist.md) — lint, SPM package tests, CocoaPods module tests, samples, pod lint
-- [Coverage design](testing/coverage-design.md) — where coverage is produced and how to treat it
-- [Firebase testing project](testing/firebase-testing-project.md) — Auth emulator project id, ports, local vs CI
+- [Agent command policy](/testing/agent-command-policy.md) — allowlisted shell commands (install, lint, unit, integration, UI, CocoaPods)
+- [Change authoring workflow](/testing/change-authoring-workflow.md) — verified change loop (unit-focused → area-focused review → commit); [§ validation evidence (blocking)](testing/change-authoring-workflow.md#validation-evidence-blocking)
+- [Iteration vocabulary](/testing/iteration-vocabulary.md) — work type, tier, and queue field identifiers
+- [Running tests](/testing/running-tests.md) — canonical SwiftUI and UIKit test commands, narrowing, emulator
+- [Validation checklist](/testing/validation-checklist.md) — lint, SPM package tests, CocoaPods module tests, samples, pod lint
+- [Coverage design](/testing/coverage-design.md) — where coverage is produced and how to treat it
+- [Firebase testing project](/testing/firebase-testing-project.md) — Auth emulator project id, ports, local vs CI
 
 # CI workflows
 
-- [CI workflows](ci-workflows/index.md) — GitHub Actions job map, Xcode/simulator pins, artifact triage
+- [CI workflows](/ci-workflows/index.md) — GitHub Actions job map, Xcode/simulator pins, artifact triage
 
 # Packaging
 
-- [SPM and CocoaPods workflow](packaging/spm-and-cocoapods-workflow.md) — dual distribution rules, product matrix, release scripts
-- [SPM / CocoaPods work queue](packaging/spm-cocoapods-work-queue.md) — ephemeral dual-distribution tracker
+- [SPM and CocoaPods workflow](/packaging/spm-and-cocoapods-workflow.md) — dual distribution rules, product matrix, release scripts
+- [SPM / CocoaPods work queue](/packaging/spm-cocoapods-work-queue.md) — ephemeral dual-distribution tracker
 
 # Packages
 
-- [Packages index](packages/index.md) — Auth SwiftUI, Database UI, Firestore UI, Storage UI
+- [Packages index](/packages/index.md) — Auth SwiftUI, Database UI, Firestore UI, Storage UI

--- a/okf-bundle/testing/validation-checklist.md
+++ b/okf-bundle/testing/validation-checklist.md
@@ -127,6 +127,6 @@ Before closing **`implementation_gate`**, **`review_gate`**, **`commit_gate`**, 
 - [ ] SPM scheme build when `Package.swift` / shared UIKit sources changed
 - [ ] `pod lib lint` when podspecs changed
 - [ ] Sample builds when samples changed
-- [ ] [Validation evidence package](#validation-evidence-package) recorded
+- [ ] [Validation evidence package](#validation-evidence-package-blocking) recorded
 - [ ] OKF bundle reviewed/updated per § above
 - [ ] Feature parity considered for user-facing Auth/UI ([`CONTRIBUTING.md`](../../CONTRIBUTING.md))


### PR DESCRIPTION
okf-bundle index TOC links were incorrect: they need to be rooted at `okf-bundle/` (leading `/…`), not plain file-relative paths.

- Update `okf-bundle/index.md` TOC entries to root-relative form (e.g. `/testing/…`, `/packaging/…`)