### PR TITLE
docs: add AGENTS.md pointing at okf-bundle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Agent entry point
+
+Start at [okf-bundle/index.md](okf-bundle/index.md).
+
+**Before editing documentation:** read [okf-bundle/documentation-policy.md](okf-bundle/documentation-policy.md).
+
+For testing or packaging work, also read:
+
+* [okf-bundle/testing/change-authoring-workflow.md](okf-bundle/testing/change-authoring-workflow.md): verified change loop
+* [okf-bundle/testing/agent-command-policy.md](okf-bundle/testing/agent-command-policy.md): allowlisted shell commands
+* [okf-bundle/testing/running-tests.md](okf-bundle/testing/running-tests.md): SwiftUI and UIKit test commands
+
+Human onboarding (CLA, SwiftUI Auth local checks): [CONTRIBUTING.md](CONTRIBUTING.md) owns that content; do not duplicate here.
+
+User-facing product behavior: [README.md](README.md) and [GETTING_STARTED.md](GETTING_STARTED.md) own that content; do not duplicate here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ For testing or packaging work, also read:
 * [okf-bundle/testing/change-authoring-workflow.md](okf-bundle/testing/change-authoring-workflow.md): verified change loop
 * [okf-bundle/testing/agent-command-policy.md](okf-bundle/testing/agent-command-policy.md): allowlisted shell commands
 * [okf-bundle/testing/running-tests.md](okf-bundle/testing/running-tests.md): SwiftUI and UIKit test commands
+* [okf-bundle/testing/validation-checklist.md](okf-bundle/testing/validation-checklist.md): pre-merge validation checklist
 
 Human onboarding (CLA, SwiftUI Auth local checks): [CONTRIBUTING.md](CONTRIBUTING.md) owns that content; do not duplicate here.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+Read [AGENTS.md](AGENTS.md) first. Follow it for this repository.


### PR DESCRIPTION
The `okf-bundle/` is already on main. Agents had no repo-root file telling them to start there.

Adds `AGENTS.md` and a `CLAUDE.md` pointer. Does not change product code or the bundle.

---
Maintainer note: Related to internal CPRN-334